### PR TITLE
Fixed optional values

### DIFF
--- a/docs/Model/Account.md
+++ b/docs/Model/Account.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **type** | **string** |  | 
 **onBudget** | **bool** | Whether this account is on budget or not | 
 **closed** | **bool** | Whether this account is closed or not | 
+**note** | **string** |  | 
 **balance** | **float** | The current balance of the account in milliunits format | 
 **clearedBalance** | **float** | The current cleared balance of the account in milliunits format | 
 **unclearedBalance** | **float** | The current uncleared balance of the account in milliunits format | 

--- a/docs/Model/BudgetDetail.md
+++ b/docs/Model/BudgetDetail.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** |  | 
 **name** | **string** |  | 
+**lastModifiedOn** | [**\DateTime**](\DateTime.md) | The last time any changes were made to the budget from either a web or mobile client. | [optional] 
 **dateFormat** | [**\YNAB\Model\DateFormat**](DateFormat.md) |  | [optional] 
 **currencyFormat** | [**\YNAB\Model\CurrencyFormat**](CurrencyFormat.md) |  | [optional] 
 **accounts** | [**\YNAB\Model\Account[]**](Account.md) |  | [optional] 

--- a/docs/Model/BudgetSummary.md
+++ b/docs/Model/BudgetSummary.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** |  | 
 **name** | **string** |  | 
+**lastModifiedOn** | [**\DateTime**](\DateTime.md) | The last time any changes were made to the budget from either a web or mobile client. | [optional] 
 **dateFormat** | [**\YNAB\Model\DateFormat**](DateFormat.md) |  | [optional] 
 **currencyFormat** | [**\YNAB\Model\CurrencyFormat**](CurrencyFormat.md) |  | [optional] 
 

--- a/docs/Model/Category.md
+++ b/docs/Model/Category.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **categoryGroupId** | **string** |  | 
 **name** | **string** |  | 
 **hidden** | **bool** | Whether or not the category is hidden | 
+**note** | **string** |  | 
 **budgeted** | **float** | Budgeted amount in current month in milliunits format | 
 **activity** | **float** | Activity amount in current month in milliunits format | 
 **balance** | **float** | Balance in current month in milliunits format | 

--- a/docs/Model/CurrencyFormat.md
+++ b/docs/Model/CurrencyFormat.md
@@ -3,6 +3,14 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isoCode** | **string** |  | 
+**exampleFormat** | **string** |  | 
+**decimalDigits** | **float** |  | 
+**decimalSeparator** | **string** |  | 
+**symbolFirst** | **bool** |  | 
+**groupSeparator** | **string** |  | 
+**currencySymbol** | **string** |  | 
+**displaySymbol** | **bool** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/DateFormat.md
+++ b/docs/Model/DateFormat.md
@@ -3,6 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**format** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/HybridTransaction.md
+++ b/docs/Model/HybridTransaction.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **date** | [**\DateTime**](\DateTime.md) |  | 
 **amount** | **float** | The transaction amount in milliunits format | 
+**memo** | **string** |  | 
 **cleared** | **string** | The cleared status of the transaction | 
 **approved** | **bool** | Whether or not the transaction is approved | 
 **flagColor** | **string** | The transaction flag | 
@@ -17,6 +18,8 @@ Name | Type | Description | Notes
 **type** | **string** | Whether the hybrid transaction represents a regular transaction or a subtransaction | 
 **parentTransactionId** | **string** | For subtransaction types, this is the id of the pararent transaction.  For transaction types, this id will be always be null. | 
 **accountName** | **string** |  | 
+**payeeName** | **string** |  | 
+**categoryName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/HybridTransaction.md
+++ b/docs/Model/HybridTransaction.md
@@ -8,8 +8,14 @@ Name | Type | Description | Notes
 **amount** | **float** | The transaction amount in milliunits format | 
 **cleared** | **string** | The cleared status of the transaction | 
 **approved** | **bool** | Whether or not the transaction is approved | 
+**flagColor** | **string** | The transaction flag | 
 **accountId** | **string** |  | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** |  | 
+**importId** | **string** | If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: &#39;YNAB:[milliunit_amount]:[iso_date]:[occurrence]&#39;.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of &#39;YNAB:-294230:2015-12-30:1&#39;.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be &#39;YNAB:-294230:2015-12-30:2&#39;. | 
 **type** | **string** | Whether the hybrid transaction represents a regular transaction or a subtransaction | 
+**parentTransactionId** | **string** | For subtransaction types, this is the id of the pararent transaction.  For transaction types, this id will be always be null. | 
 **accountName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/Model/MonthDetail.md
+++ b/docs/Model/MonthDetail.md
@@ -5,6 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **month** | [**\DateTime**](\DateTime.md) |  | 
 **note** | **string** |  | 
+**toBeBudgeted** | **float** | The current balance of the account in milliunits format | 
+**ageOfMoney** | **float** |  | 
 **categories** | [**\YNAB\Model\Category[]**](Category.md) | The budget month categories | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/Model/MonthDetail.md
+++ b/docs/Model/MonthDetail.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **month** | [**\DateTime**](\DateTime.md) |  | 
+**note** | **string** |  | 
 **categories** | [**\YNAB\Model\Category[]**](Category.md) | The budget month categories | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/Model/MonthSummary.md
+++ b/docs/Model/MonthSummary.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **month** | [**\DateTime**](\DateTime.md) |  | 
+**note** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/MonthSummary.md
+++ b/docs/Model/MonthSummary.md
@@ -5,6 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **month** | [**\DateTime**](\DateTime.md) |  | 
 **note** | **string** |  | 
+**toBeBudgeted** | **float** | The current balance of the account in milliunits format | 
+**ageOfMoney** | **float** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/Payee.md
+++ b/docs/Model/Payee.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** |  | 
 **name** | **string** |  | 
+**transferAccountId** | **string** | If a transfer payee, the account_id to which this payee transfers to | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/PayeeLocation.md
+++ b/docs/Model/PayeeLocation.md
@@ -5,6 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** |  | 
 **payeeId** | **string** |  | 
+**latitude** | **string** |  | 
+**longitude** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/SaveTransaction.md
+++ b/docs/Model/SaveTransaction.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **payeeId** | **string** | The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied. | [optional] 
 **payeeName** | **string** | The payee name.  If a payee_name value is provided and payee_id is not included or has a null value, payee_name will be used to create or use an existing payee. | [optional] 
 **categoryId** | **string** | The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied. | [optional] 
+**memo** | **string** |  | [optional] 
 **cleared** | **string** | The cleared status of the transaction | [optional] 
 **approved** | **bool** | Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default. | [optional] 
 **flagColor** | **string** | The transaction flag | [optional] 

--- a/docs/Model/SaveTransaction.md
+++ b/docs/Model/SaveTransaction.md
@@ -6,8 +6,13 @@ Name | Type | Description | Notes
 **accountId** | **string** |  | 
 **date** | [**\DateTime**](\DateTime.md) |  | 
 **amount** | **float** | The transaction amount in milliunits format | 
+**payeeId** | **string** | The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied. | [optional] 
+**payeeName** | **string** | The payee name.  If a payee_name value is provided and payee_id is not included or has a null value, payee_name will be used to create or use an existing payee. | [optional] 
+**categoryId** | **string** | The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied. | [optional] 
 **cleared** | **string** | The cleared status of the transaction | [optional] 
 **approved** | **bool** | Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default. | [optional] 
+**flagColor** | **string** | The transaction flag | [optional] 
+**importId** | **string** | If specified for a new transaction, the transaction will be treated as Imported and assigned this import_id.  If another transaction on the same account with this same import_id is later attempted to be created, it will be skipped to prevent duplication.  Transactions imported through File Based Import or Direct Import and not through the API, are assigned an import_id in the format: &#39;YNAB:[milliunit_amount]:[iso_date]:[occurrence]&#39;.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of &#39;YNAB:-294230:2015-12-30:1&#39;.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be &#39;YNAB:-294230:2015-12-30:2&#39;.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.  If import_id is specified as null, the transaction will be treated as a user entered transaction. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/ScheduledSubTransaction.md
+++ b/docs/Model/ScheduledSubTransaction.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **scheduledTransactionId** | **string** |  | 
 **amount** | **float** | The scheduled subtransaction amount in milliunits format | 
+**memo** | **string** |  | 
 **payeeId** | **string** |  | 
 **categoryId** | **string** |  | 
 **transferAccountId** | **string** | If a transfer, the account_id which the scheduled sub transaction transfers to | 

--- a/docs/Model/ScheduledSubTransaction.md
+++ b/docs/Model/ScheduledSubTransaction.md
@@ -6,6 +6,9 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **scheduledTransactionId** | **string** |  | 
 **amount** | **float** | The scheduled subtransaction amount in milliunits format | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** | If a transfer, the account_id which the scheduled sub transaction transfers to | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/ScheduledTransactionDetail.md
+++ b/docs/Model/ScheduledTransactionDetail.md
@@ -8,12 +8,15 @@ Name | Type | Description | Notes
 **dateNext** | [**\DateTime**](\DateTime.md) | The next date for which the Scheduled Transaction is scheduled. | 
 **frequency** | **string** |  | 
 **amount** | **float** | The scheduled transaction amount in milliunits format | 
+**memo** | **string** |  | 
 **flagColor** | **string** | The scheduled transaction flag | 
 **accountId** | **string** |  | 
 **payeeId** | **string** |  | 
 **categoryId** | **string** |  | 
 **transferAccountId** | **string** | If a transfer, the account_id which the scheduled transaction transfers to | 
 **accountName** | **string** |  | 
+**payeeName** | **string** |  | 
+**categoryName** | **string** |  | 
 **subtransactions** | [**\YNAB\Model\ScheduledSubTransaction[]**](ScheduledSubTransaction.md) | If a split scheduled transaction, the subtransactions. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/Model/ScheduledTransactionDetail.md
+++ b/docs/Model/ScheduledTransactionDetail.md
@@ -8,7 +8,11 @@ Name | Type | Description | Notes
 **dateNext** | [**\DateTime**](\DateTime.md) | The next date for which the Scheduled Transaction is scheduled. | 
 **frequency** | **string** |  | 
 **amount** | **float** | The scheduled transaction amount in milliunits format | 
+**flagColor** | **string** | The scheduled transaction flag | 
 **accountId** | **string** |  | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** | If a transfer, the account_id which the scheduled transaction transfers to | 
 **accountName** | **string** |  | 
 **subtransactions** | [**\YNAB\Model\ScheduledSubTransaction[]**](ScheduledSubTransaction.md) | If a split scheduled transaction, the subtransactions. | 
 

--- a/docs/Model/ScheduledTransactionSummary.md
+++ b/docs/Model/ScheduledTransactionSummary.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **dateNext** | [**\DateTime**](\DateTime.md) | The next date for which the Scheduled Transaction is scheduled. | 
 **frequency** | **string** |  | 
 **amount** | **float** | The scheduled transaction amount in milliunits format | 
+**memo** | **string** |  | 
 **flagColor** | **string** | The scheduled transaction flag | 
 **accountId** | **string** |  | 
 **payeeId** | **string** |  | 

--- a/docs/Model/ScheduledTransactionSummary.md
+++ b/docs/Model/ScheduledTransactionSummary.md
@@ -8,7 +8,11 @@ Name | Type | Description | Notes
 **dateNext** | [**\DateTime**](\DateTime.md) | The next date for which the Scheduled Transaction is scheduled. | 
 **frequency** | **string** |  | 
 **amount** | **float** | The scheduled transaction amount in milliunits format | 
+**flagColor** | **string** | The scheduled transaction flag | 
 **accountId** | **string** |  | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** | If a transfer, the account_id which the scheduled transaction transfers to | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/SubTransaction.md
+++ b/docs/Model/SubTransaction.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **transactionId** | **string** |  | 
 **amount** | **float** | The subtransaction amount in milliunits format | 
+**memo** | **string** |  | 
 **payeeId** | **string** |  | 
 **categoryId** | **string** |  | 
 **transferAccountId** | **string** | If a transfer, the account_id which the subtransaction transfers to | 

--- a/docs/Model/SubTransaction.md
+++ b/docs/Model/SubTransaction.md
@@ -6,6 +6,9 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **transactionId** | **string** |  | 
 **amount** | **float** | The subtransaction amount in milliunits format | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** | If a transfer, the account_id which the subtransaction transfers to | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/TransactionDetail.md
+++ b/docs/Model/TransactionDetail.md
@@ -8,7 +8,12 @@ Name | Type | Description | Notes
 **amount** | **float** | The transaction amount in milliunits format | 
 **cleared** | **string** | The cleared status of the transaction | 
 **approved** | **bool** | Whether or not the transaction is approved | 
+**flagColor** | **string** | The transaction flag | 
 **accountId** | **string** |  | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** |  | 
+**importId** | **string** | If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: &#39;YNAB:[milliunit_amount]:[iso_date]:[occurrence]&#39;.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of &#39;YNAB:-294230:2015-12-30:1&#39;.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be &#39;YNAB:-294230:2015-12-30:2&#39;. | 
 **accountName** | **string** |  | 
 **subtransactions** | [**\YNAB\Model\SubTransaction[]**](SubTransaction.md) | If a split transaction, the subtransactions. | 
 

--- a/docs/Model/TransactionDetail.md
+++ b/docs/Model/TransactionDetail.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **date** | [**\DateTime**](\DateTime.md) |  | 
 **amount** | **float** | The transaction amount in milliunits format | 
+**memo** | **string** |  | 
 **cleared** | **string** | The cleared status of the transaction | 
 **approved** | **bool** | Whether or not the transaction is approved | 
 **flagColor** | **string** | The transaction flag | 
@@ -15,6 +16,8 @@ Name | Type | Description | Notes
 **transferAccountId** | **string** |  | 
 **importId** | **string** | If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: &#39;YNAB:[milliunit_amount]:[iso_date]:[occurrence]&#39;.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of &#39;YNAB:-294230:2015-12-30:1&#39;.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be &#39;YNAB:-294230:2015-12-30:2&#39;. | 
 **accountName** | **string** |  | 
+**payeeName** | **string** |  | 
+**categoryName** | **string** |  | 
 **subtransactions** | [**\YNAB\Model\SubTransaction[]**](SubTransaction.md) | If a split transaction, the subtransactions. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/Model/TransactionSummary.md
+++ b/docs/Model/TransactionSummary.md
@@ -8,7 +8,12 @@ Name | Type | Description | Notes
 **amount** | **float** | The transaction amount in milliunits format | 
 **cleared** | **string** | The cleared status of the transaction | 
 **approved** | **bool** | Whether or not the transaction is approved | 
+**flagColor** | **string** | The transaction flag | 
 **accountId** | **string** |  | 
+**payeeId** | **string** |  | 
+**categoryId** | **string** |  | 
+**transferAccountId** | **string** |  | 
+**importId** | **string** | If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: &#39;YNAB:[milliunit_amount]:[iso_date]:[occurrence]&#39;.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of &#39;YNAB:-294230:2015-12-30:1&#39;.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be &#39;YNAB:-294230:2015-12-30:2&#39;. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/Model/TransactionSummary.md
+++ b/docs/Model/TransactionSummary.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **id** | **string** |  | 
 **date** | [**\DateTime**](\DateTime.md) |  | 
 **amount** | **float** | The transaction amount in milliunits format | 
+**memo** | **string** |  | 
 **cleared** | **string** | The cleared status of the transaction | 
 **approved** | **bool** | Whether or not the transaction is approved | 
 **flagColor** | **string** | The transaction flag | 

--- a/generate/generate
+++ b/generate/generate
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-swagger-codegen generate -i "https://api.youneedabudget.com/papi/spec-v1-swagger.json" \
+swagger-codegen generate -i "./YNAB-SDK-PHP/swagger.json" \
     -l "php" \
     -c "./YNAB-SDK-PHP/generate/swagger-config-php.json" \
     --ignore-file-override="./YNAB-SDK-PHP/.swagger-codegen-ignore" \

--- a/src/Model/Account.php
+++ b/src/Model/Account.php
@@ -62,6 +62,7 @@ class Account implements ModelInterface, ArrayAccess
         'type' => 'string',
         'onBudget' => 'bool',
         'closed' => 'bool',
+        'note' => 'string',
         'balance' => 'float',
         'clearedBalance' => 'float',
         'unclearedBalance' => 'float'
@@ -78,6 +79,7 @@ class Account implements ModelInterface, ArrayAccess
         'type' => null,
         'onBudget' => null,
         'closed' => null,
+        'note' => null,
         'balance' => '1234000',
         'clearedBalance' => '1234000',
         'unclearedBalance' => '1234000'
@@ -115,6 +117,7 @@ class Account implements ModelInterface, ArrayAccess
         'type' => 'type',
         'onBudget' => 'on_budget',
         'closed' => 'closed',
+        'note' => 'note',
         'balance' => 'balance',
         'clearedBalance' => 'cleared_balance',
         'unclearedBalance' => 'uncleared_balance'
@@ -131,6 +134,7 @@ class Account implements ModelInterface, ArrayAccess
         'type' => 'setType',
         'onBudget' => 'setOnBudget',
         'closed' => 'setClosed',
+        'note' => 'setNote',
         'balance' => 'setBalance',
         'clearedBalance' => 'setClearedBalance',
         'unclearedBalance' => 'setUnclearedBalance'
@@ -147,6 +151,7 @@ class Account implements ModelInterface, ArrayAccess
         'type' => 'getType',
         'onBudget' => 'getOnBudget',
         'closed' => 'getClosed',
+        'note' => 'getNote',
         'balance' => 'getBalance',
         'clearedBalance' => 'getClearedBalance',
         'unclearedBalance' => 'getUnclearedBalance'
@@ -250,6 +255,7 @@ class Account implements ModelInterface, ArrayAccess
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['onBudget'] = isset($data['onBudget']) ? $data['onBudget'] : null;
         $this->container['closed'] = isset($data['closed']) ? $data['closed'] : null;
+        $this->container['note'] = isset($data['note']) ? $data['note'] : null;
         $this->container['balance'] = isset($data['balance']) ? $data['balance'] : null;
         $this->container['clearedBalance'] = isset($data['clearedBalance']) ? $data['clearedBalance'] : null;
         $this->container['unclearedBalance'] = isset($data['unclearedBalance']) ? $data['unclearedBalance'] : null;
@@ -286,6 +292,9 @@ class Account implements ModelInterface, ArrayAccess
         }
         if ($this->container['closed'] === null) {
             $invalidProperties[] = "'closed' can't be null";
+        }
+        if ($this->container['note'] === null) {
+            $invalidProperties[] = "'note' can't be null";
         }
         if ($this->container['balance'] === null) {
             $invalidProperties[] = "'balance' can't be null";
@@ -325,6 +334,9 @@ class Account implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['closed'] === null) {
+            return false;
+        }
+        if ($this->container['note'] === null) {
             return false;
         }
         if ($this->container['balance'] === null) {
@@ -465,6 +477,30 @@ class Account implements ModelInterface, ArrayAccess
     public function setClosed($closed)
     {
         $this->container['closed'] = $closed;
+
+        return $this;
+    }
+
+    /**
+     * Gets note
+     *
+     * @return string
+     */
+    public function getNote()
+    {
+        return $this->container['note'];
+    }
+
+    /**
+     * Sets note
+     *
+     * @param string $note note
+     *
+     * @return $this
+     */
+    public function setNote($note)
+    {
+        $this->container['note'] = $note;
 
         return $this;
     }

--- a/src/Model/BudgetDetail.php
+++ b/src/Model/BudgetDetail.php
@@ -59,6 +59,7 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     protected static $swaggerTypes = [
         'id' => 'string',
         'name' => 'string',
+        'lastModifiedOn' => '\DateTime',
         'dateFormat' => '\YNAB\Model\DateFormat',
         'currencyFormat' => '\YNAB\Model\CurrencyFormat',
         'accounts' => '\YNAB\Model\Account[]',
@@ -81,6 +82,7 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     protected static $swaggerFormats = [
         'id' => 'uuid',
         'name' => null,
+        'lastModifiedOn' => 'date-time',
         'dateFormat' => null,
         'currencyFormat' => null,
         'accounts' => null,
@@ -124,6 +126,7 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     protected static $attributeMap = [
         'id' => 'id',
         'name' => 'name',
+        'lastModifiedOn' => 'last_modified_on',
         'dateFormat' => 'date_format',
         'currencyFormat' => 'currency_format',
         'accounts' => 'accounts',
@@ -146,6 +149,7 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     protected static $setters = [
         'id' => 'setId',
         'name' => 'setName',
+        'lastModifiedOn' => 'setLastModifiedOn',
         'dateFormat' => 'setDateFormat',
         'currencyFormat' => 'setCurrencyFormat',
         'accounts' => 'setAccounts',
@@ -168,6 +172,7 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     protected static $getters = [
         'id' => 'getId',
         'name' => 'getName',
+        'lastModifiedOn' => 'getLastModifiedOn',
         'dateFormat' => 'getDateFormat',
         'currencyFormat' => 'getCurrencyFormat',
         'accounts' => 'getAccounts',
@@ -244,6 +249,7 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
+        $this->container['lastModifiedOn'] = isset($data['lastModifiedOn']) ? $data['lastModifiedOn'] : null;
         $this->container['dateFormat'] = isset($data['dateFormat']) ? $data['dateFormat'] : null;
         $this->container['currencyFormat'] = isset($data['currencyFormat']) ? $data['currencyFormat'] : null;
         $this->container['accounts'] = isset($data['accounts']) ? $data['accounts'] : null;
@@ -339,6 +345,30 @@ class BudgetDetail implements ModelInterface, ArrayAccess
     public function setName($name)
     {
         $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets lastModifiedOn
+     *
+     * @return \DateTime
+     */
+    public function getLastModifiedOn()
+    {
+        return $this->container['lastModifiedOn'];
+    }
+
+    /**
+     * Sets lastModifiedOn
+     *
+     * @param \DateTime $lastModifiedOn The last time any changes were made to the budget from either a web or mobile client.
+     *
+     * @return $this
+     */
+    public function setLastModifiedOn($lastModifiedOn)
+    {
+        $this->container['lastModifiedOn'] = $lastModifiedOn;
 
         return $this;
     }

--- a/src/Model/BudgetSummary.php
+++ b/src/Model/BudgetSummary.php
@@ -59,6 +59,7 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     protected static $swaggerTypes = [
         'id' => 'string',
         'name' => 'string',
+        'lastModifiedOn' => '\DateTime',
         'dateFormat' => '\YNAB\Model\DateFormat',
         'currencyFormat' => '\YNAB\Model\CurrencyFormat'
     ];
@@ -71,6 +72,7 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     protected static $swaggerFormats = [
         'id' => 'uuid',
         'name' => null,
+        'lastModifiedOn' => 'date-time',
         'dateFormat' => null,
         'currencyFormat' => null
     ];
@@ -104,6 +106,7 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     protected static $attributeMap = [
         'id' => 'id',
         'name' => 'name',
+        'lastModifiedOn' => 'last_modified_on',
         'dateFormat' => 'date_format',
         'currencyFormat' => 'currency_format'
     ];
@@ -116,6 +119,7 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     protected static $setters = [
         'id' => 'setId',
         'name' => 'setName',
+        'lastModifiedOn' => 'setLastModifiedOn',
         'dateFormat' => 'setDateFormat',
         'currencyFormat' => 'setCurrencyFormat'
     ];
@@ -128,6 +132,7 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     protected static $getters = [
         'id' => 'getId',
         'name' => 'getName',
+        'lastModifiedOn' => 'getLastModifiedOn',
         'dateFormat' => 'getDateFormat',
         'currencyFormat' => 'getCurrencyFormat'
     ];
@@ -194,6 +199,7 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
+        $this->container['lastModifiedOn'] = isset($data['lastModifiedOn']) ? $data['lastModifiedOn'] : null;
         $this->container['dateFormat'] = isset($data['dateFormat']) ? $data['dateFormat'] : null;
         $this->container['currencyFormat'] = isset($data['currencyFormat']) ? $data['currencyFormat'] : null;
     }
@@ -279,6 +285,30 @@ class BudgetSummary implements ModelInterface, ArrayAccess
     public function setName($name)
     {
         $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets lastModifiedOn
+     *
+     * @return \DateTime
+     */
+    public function getLastModifiedOn()
+    {
+        return $this->container['lastModifiedOn'];
+    }
+
+    /**
+     * Sets lastModifiedOn
+     *
+     * @param \DateTime $lastModifiedOn The last time any changes were made to the budget from either a web or mobile client.
+     *
+     * @return $this
+     */
+    public function setLastModifiedOn($lastModifiedOn)
+    {
+        $this->container['lastModifiedOn'] = $lastModifiedOn;
 
         return $this;
     }

--- a/src/Model/Category.php
+++ b/src/Model/Category.php
@@ -61,6 +61,7 @@ class Category implements ModelInterface, ArrayAccess
         'categoryGroupId' => 'string',
         'name' => 'string',
         'hidden' => 'bool',
+        'note' => 'string',
         'budgeted' => 'float',
         'activity' => 'float',
         'balance' => 'float'
@@ -76,6 +77,7 @@ class Category implements ModelInterface, ArrayAccess
         'categoryGroupId' => 'uuid',
         'name' => null,
         'hidden' => null,
+        'note' => null,
         'budgeted' => null,
         'activity' => null,
         'balance' => null
@@ -112,6 +114,7 @@ class Category implements ModelInterface, ArrayAccess
         'categoryGroupId' => 'category_group_id',
         'name' => 'name',
         'hidden' => 'hidden',
+        'note' => 'note',
         'budgeted' => 'budgeted',
         'activity' => 'activity',
         'balance' => 'balance'
@@ -127,6 +130,7 @@ class Category implements ModelInterface, ArrayAccess
         'categoryGroupId' => 'setCategoryGroupId',
         'name' => 'setName',
         'hidden' => 'setHidden',
+        'note' => 'setNote',
         'budgeted' => 'setBudgeted',
         'activity' => 'setActivity',
         'balance' => 'setBalance'
@@ -142,6 +146,7 @@ class Category implements ModelInterface, ArrayAccess
         'categoryGroupId' => 'getCategoryGroupId',
         'name' => 'getName',
         'hidden' => 'getHidden',
+        'note' => 'getNote',
         'budgeted' => 'getBudgeted',
         'activity' => 'getActivity',
         'balance' => 'getBalance'
@@ -211,6 +216,7 @@ class Category implements ModelInterface, ArrayAccess
         $this->container['categoryGroupId'] = isset($data['categoryGroupId']) ? $data['categoryGroupId'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['hidden'] = isset($data['hidden']) ? $data['hidden'] : null;
+        $this->container['note'] = isset($data['note']) ? $data['note'] : null;
         $this->container['budgeted'] = isset($data['budgeted']) ? $data['budgeted'] : null;
         $this->container['activity'] = isset($data['activity']) ? $data['activity'] : null;
         $this->container['balance'] = isset($data['balance']) ? $data['balance'] : null;
@@ -236,6 +242,9 @@ class Category implements ModelInterface, ArrayAccess
         }
         if ($this->container['hidden'] === null) {
             $invalidProperties[] = "'hidden' can't be null";
+        }
+        if ($this->container['note'] === null) {
+            $invalidProperties[] = "'note' can't be null";
         }
         if ($this->container['budgeted'] === null) {
             $invalidProperties[] = "'budgeted' can't be null";
@@ -268,6 +277,9 @@ class Category implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['hidden'] === null) {
+            return false;
+        }
+        if ($this->container['note'] === null) {
             return false;
         }
         if ($this->container['budgeted'] === null) {
@@ -375,6 +387,30 @@ class Category implements ModelInterface, ArrayAccess
     public function setHidden($hidden)
     {
         $this->container['hidden'] = $hidden;
+
+        return $this;
+    }
+
+    /**
+     * Gets note
+     *
+     * @return string
+     */
+    public function getNote()
+    {
+        return $this->container['note'];
+    }
+
+    /**
+     * Sets note
+     *
+     * @param string $note note
+     *
+     * @return $this
+     */
+    public function setNote($note)
+    {
+        $this->container['note'] = $note;
 
         return $this;
     }

--- a/src/Model/CurrencyFormat.php
+++ b/src/Model/CurrencyFormat.php
@@ -57,7 +57,14 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        
+        'isoCode' => 'string',
+        'exampleFormat' => 'string',
+        'decimalDigits' => 'float',
+        'decimalSeparator' => 'string',
+        'symbolFirst' => 'bool',
+        'groupSeparator' => 'string',
+        'currencySymbol' => 'string',
+        'displaySymbol' => 'bool'
     ];
 
     /**
@@ -66,7 +73,14 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        
+        'isoCode' => null,
+        'exampleFormat' => null,
+        'decimalDigits' => null,
+        'decimalSeparator' => null,
+        'symbolFirst' => null,
+        'groupSeparator' => null,
+        'currencySymbol' => null,
+        'displaySymbol' => null
     ];
 
     /**
@@ -96,7 +110,14 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        
+        'isoCode' => 'iso_code',
+        'exampleFormat' => 'example_format',
+        'decimalDigits' => 'decimal_digits',
+        'decimalSeparator' => 'decimal_separator',
+        'symbolFirst' => 'symbol_first',
+        'groupSeparator' => 'group_separator',
+        'currencySymbol' => 'currency_symbol',
+        'displaySymbol' => 'display_symbol'
     ];
 
     /**
@@ -105,7 +126,14 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        
+        'isoCode' => 'setIsoCode',
+        'exampleFormat' => 'setExampleFormat',
+        'decimalDigits' => 'setDecimalDigits',
+        'decimalSeparator' => 'setDecimalSeparator',
+        'symbolFirst' => 'setSymbolFirst',
+        'groupSeparator' => 'setGroupSeparator',
+        'currencySymbol' => 'setCurrencySymbol',
+        'displaySymbol' => 'setDisplaySymbol'
     ];
 
     /**
@@ -114,7 +142,14 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        
+        'isoCode' => 'getIsoCode',
+        'exampleFormat' => 'getExampleFormat',
+        'decimalDigits' => 'getDecimalDigits',
+        'decimalSeparator' => 'getDecimalSeparator',
+        'symbolFirst' => 'getSymbolFirst',
+        'groupSeparator' => 'getGroupSeparator',
+        'currencySymbol' => 'getCurrencySymbol',
+        'displaySymbol' => 'getDisplaySymbol'
     ];
 
     /**
@@ -177,6 +212,14 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
+        $this->container['isoCode'] = isset($data['isoCode']) ? $data['isoCode'] : null;
+        $this->container['exampleFormat'] = isset($data['exampleFormat']) ? $data['exampleFormat'] : null;
+        $this->container['decimalDigits'] = isset($data['decimalDigits']) ? $data['decimalDigits'] : null;
+        $this->container['decimalSeparator'] = isset($data['decimalSeparator']) ? $data['decimalSeparator'] : null;
+        $this->container['symbolFirst'] = isset($data['symbolFirst']) ? $data['symbolFirst'] : null;
+        $this->container['groupSeparator'] = isset($data['groupSeparator']) ? $data['groupSeparator'] : null;
+        $this->container['currencySymbol'] = isset($data['currencySymbol']) ? $data['currencySymbol'] : null;
+        $this->container['displaySymbol'] = isset($data['displaySymbol']) ? $data['displaySymbol'] : null;
     }
 
     /**
@@ -188,6 +231,30 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
+        if ($this->container['isoCode'] === null) {
+            $invalidProperties[] = "'isoCode' can't be null";
+        }
+        if ($this->container['exampleFormat'] === null) {
+            $invalidProperties[] = "'exampleFormat' can't be null";
+        }
+        if ($this->container['decimalDigits'] === null) {
+            $invalidProperties[] = "'decimalDigits' can't be null";
+        }
+        if ($this->container['decimalSeparator'] === null) {
+            $invalidProperties[] = "'decimalSeparator' can't be null";
+        }
+        if ($this->container['symbolFirst'] === null) {
+            $invalidProperties[] = "'symbolFirst' can't be null";
+        }
+        if ($this->container['groupSeparator'] === null) {
+            $invalidProperties[] = "'groupSeparator' can't be null";
+        }
+        if ($this->container['currencySymbol'] === null) {
+            $invalidProperties[] = "'currencySymbol' can't be null";
+        }
+        if ($this->container['displaySymbol'] === null) {
+            $invalidProperties[] = "'displaySymbol' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -200,9 +267,225 @@ class CurrencyFormat implements ModelInterface, ArrayAccess
     public function valid()
     {
 
+        if ($this->container['isoCode'] === null) {
+            return false;
+        }
+        if ($this->container['exampleFormat'] === null) {
+            return false;
+        }
+        if ($this->container['decimalDigits'] === null) {
+            return false;
+        }
+        if ($this->container['decimalSeparator'] === null) {
+            return false;
+        }
+        if ($this->container['symbolFirst'] === null) {
+            return false;
+        }
+        if ($this->container['groupSeparator'] === null) {
+            return false;
+        }
+        if ($this->container['currencySymbol'] === null) {
+            return false;
+        }
+        if ($this->container['displaySymbol'] === null) {
+            return false;
+        }
         return true;
     }
 
+
+    /**
+     * Gets isoCode
+     *
+     * @return string
+     */
+    public function getIsoCode()
+    {
+        return $this->container['isoCode'];
+    }
+
+    /**
+     * Sets isoCode
+     *
+     * @param string $isoCode isoCode
+     *
+     * @return $this
+     */
+    public function setIsoCode($isoCode)
+    {
+        $this->container['isoCode'] = $isoCode;
+
+        return $this;
+    }
+
+    /**
+     * Gets exampleFormat
+     *
+     * @return string
+     */
+    public function getExampleFormat()
+    {
+        return $this->container['exampleFormat'];
+    }
+
+    /**
+     * Sets exampleFormat
+     *
+     * @param string $exampleFormat exampleFormat
+     *
+     * @return $this
+     */
+    public function setExampleFormat($exampleFormat)
+    {
+        $this->container['exampleFormat'] = $exampleFormat;
+
+        return $this;
+    }
+
+    /**
+     * Gets decimalDigits
+     *
+     * @return float
+     */
+    public function getDecimalDigits()
+    {
+        return $this->container['decimalDigits'];
+    }
+
+    /**
+     * Sets decimalDigits
+     *
+     * @param float $decimalDigits decimalDigits
+     *
+     * @return $this
+     */
+    public function setDecimalDigits($decimalDigits)
+    {
+        $this->container['decimalDigits'] = $decimalDigits;
+
+        return $this;
+    }
+
+    /**
+     * Gets decimalSeparator
+     *
+     * @return string
+     */
+    public function getDecimalSeparator()
+    {
+        return $this->container['decimalSeparator'];
+    }
+
+    /**
+     * Sets decimalSeparator
+     *
+     * @param string $decimalSeparator decimalSeparator
+     *
+     * @return $this
+     */
+    public function setDecimalSeparator($decimalSeparator)
+    {
+        $this->container['decimalSeparator'] = $decimalSeparator;
+
+        return $this;
+    }
+
+    /**
+     * Gets symbolFirst
+     *
+     * @return bool
+     */
+    public function getSymbolFirst()
+    {
+        return $this->container['symbolFirst'];
+    }
+
+    /**
+     * Sets symbolFirst
+     *
+     * @param bool $symbolFirst symbolFirst
+     *
+     * @return $this
+     */
+    public function setSymbolFirst($symbolFirst)
+    {
+        $this->container['symbolFirst'] = $symbolFirst;
+
+        return $this;
+    }
+
+    /**
+     * Gets groupSeparator
+     *
+     * @return string
+     */
+    public function getGroupSeparator()
+    {
+        return $this->container['groupSeparator'];
+    }
+
+    /**
+     * Sets groupSeparator
+     *
+     * @param string $groupSeparator groupSeparator
+     *
+     * @return $this
+     */
+    public function setGroupSeparator($groupSeparator)
+    {
+        $this->container['groupSeparator'] = $groupSeparator;
+
+        return $this;
+    }
+
+    /**
+     * Gets currencySymbol
+     *
+     * @return string
+     */
+    public function getCurrencySymbol()
+    {
+        return $this->container['currencySymbol'];
+    }
+
+    /**
+     * Sets currencySymbol
+     *
+     * @param string $currencySymbol currencySymbol
+     *
+     * @return $this
+     */
+    public function setCurrencySymbol($currencySymbol)
+    {
+        $this->container['currencySymbol'] = $currencySymbol;
+
+        return $this;
+    }
+
+    /**
+     * Gets displaySymbol
+     *
+     * @return bool
+     */
+    public function getDisplaySymbol()
+    {
+        return $this->container['displaySymbol'];
+    }
+
+    /**
+     * Sets displaySymbol
+     *
+     * @param bool $displaySymbol displaySymbol
+     *
+     * @return $this
+     */
+    public function setDisplaySymbol($displaySymbol)
+    {
+        $this->container['displaySymbol'] = $displaySymbol;
+
+        return $this;
+    }
     /**
      * Returns true if offset exists. False otherwise.
      *

--- a/src/Model/DateFormat.php
+++ b/src/Model/DateFormat.php
@@ -57,7 +57,7 @@ class DateFormat implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        
+        'format' => 'string'
     ];
 
     /**
@@ -66,7 +66,7 @@ class DateFormat implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        
+        'format' => null
     ];
 
     /**
@@ -96,7 +96,7 @@ class DateFormat implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        
+        'format' => 'format'
     ];
 
     /**
@@ -105,7 +105,7 @@ class DateFormat implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        
+        'format' => 'setFormat'
     ];
 
     /**
@@ -114,7 +114,7 @@ class DateFormat implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        
+        'format' => 'getFormat'
     ];
 
     /**
@@ -177,6 +177,7 @@ class DateFormat implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
+        $this->container['format'] = isset($data['format']) ? $data['format'] : null;
     }
 
     /**
@@ -188,6 +189,9 @@ class DateFormat implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
+        if ($this->container['format'] === null) {
+            $invalidProperties[] = "'format' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -200,9 +204,36 @@ class DateFormat implements ModelInterface, ArrayAccess
     public function valid()
     {
 
+        if ($this->container['format'] === null) {
+            return false;
+        }
         return true;
     }
 
+
+    /**
+     * Gets format
+     *
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->container['format'];
+    }
+
+    /**
+     * Sets format
+     *
+     * @param string $format format
+     *
+     * @return $this
+     */
+    public function setFormat($format)
+    {
+        $this->container['format'] = $format;
+
+        return $this;
+    }
     /**
      * Returns true if offset exists. False otherwise.
      *

--- a/src/Model/HybridTransaction.php
+++ b/src/Model/HybridTransaction.php
@@ -62,8 +62,14 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'amount' => 'float',
         'cleared' => 'string',
         'approved' => 'bool',
+        'flagColor' => 'string',
         'accountId' => 'string',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string',
+        'importId' => 'string',
         'type' => 'string',
+        'parentTransactionId' => 'string',
         'accountName' => 'string'
     ];
 
@@ -78,8 +84,14 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'amount' => '1234000',
         'cleared' => null,
         'approved' => null,
+        'flagColor' => null,
         'accountId' => 'uuid',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid',
+        'importId' => null,
         'type' => null,
+        'parentTransactionId' => 'uuid',
         'accountName' => null
     ];
 
@@ -115,8 +127,14 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'amount' => 'amount',
         'cleared' => 'cleared',
         'approved' => 'approved',
+        'flagColor' => 'flag_color',
         'accountId' => 'account_id',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id',
+        'importId' => 'import_id',
         'type' => 'type',
+        'parentTransactionId' => 'parent_transaction_id',
         'accountName' => 'account_name'
     ];
 
@@ -131,8 +149,14 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'amount' => 'setAmount',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
+        'flagColor' => 'setFlagColor',
         'accountId' => 'setAccountId',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId',
+        'importId' => 'setImportId',
         'type' => 'setType',
+        'parentTransactionId' => 'setParentTransactionId',
         'accountName' => 'setAccountName'
     ];
 
@@ -147,8 +171,14 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'amount' => 'getAmount',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
+        'flagColor' => 'getFlagColor',
         'accountId' => 'getAccountId',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId',
+        'importId' => 'getImportId',
         'type' => 'getType',
+        'parentTransactionId' => 'getParentTransactionId',
         'accountName' => 'getAccountName'
     ];
 
@@ -196,6 +226,12 @@ class HybridTransaction implements ModelInterface, ArrayAccess
     const CLEARED_CLEARED = 'cleared';
     const CLEARED_UNCLEARED = 'uncleared';
     const CLEARED_RECONCILED = 'reconciled';
+    const FLAG_COLOR_RED = 'red';
+    const FLAG_COLOR_ORANGE = 'orange';
+    const FLAG_COLOR_YELLOW = 'yellow';
+    const FLAG_COLOR_GREEN = 'green';
+    const FLAG_COLOR_BLUE = 'blue';
+    const FLAG_COLOR_PURPLE = 'purple';
     const TYPE_TRANSACTION = 'transaction';
     const TYPE_SUBTRANSACTION = 'subtransaction';
     
@@ -212,6 +248,23 @@ class HybridTransaction implements ModelInterface, ArrayAccess
             self::CLEARED_CLEARED,
             self::CLEARED_UNCLEARED,
             self::CLEARED_RECONCILED,
+        ];
+    }
+    
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getFlagColorAllowableValues()
+    {
+        return [
+            self::FLAG_COLOR_RED,
+            self::FLAG_COLOR_ORANGE,
+            self::FLAG_COLOR_YELLOW,
+            self::FLAG_COLOR_GREEN,
+            self::FLAG_COLOR_BLUE,
+            self::FLAG_COLOR_PURPLE,
         ];
     }
     
@@ -249,8 +302,14 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
+        $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
+        $this->container['importId'] = isset($data['importId']) ? $data['importId'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
+        $this->container['parentTransactionId'] = isset($data['parentTransactionId']) ? $data['parentTransactionId'] : null;
         $this->container['accountName'] = isset($data['accountName']) ? $data['accountName'] : null;
     }
 
@@ -286,8 +345,31 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         if ($this->container['approved'] === null) {
             $invalidProperties[] = "'approved' can't be null";
         }
+        if ($this->container['flagColor'] === null) {
+            $invalidProperties[] = "'flagColor' can't be null";
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'flagColor', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
         if ($this->container['accountId'] === null) {
             $invalidProperties[] = "'accountId' can't be null";
+        }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
+        }
+        if ($this->container['importId'] === null) {
+            $invalidProperties[] = "'importId' can't be null";
         }
         if ($this->container['type'] === null) {
             $invalidProperties[] = "'type' can't be null";
@@ -300,6 +382,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
             );
         }
 
+        if ($this->container['parentTransactionId'] === null) {
+            $invalidProperties[] = "'parentTransactionId' can't be null";
+        }
         if ($this->container['accountName'] === null) {
             $invalidProperties[] = "'accountName' can't be null";
         }
@@ -334,7 +419,26 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         if ($this->container['approved'] === null) {
             return false;
         }
+        if ($this->container['flagColor'] === null) {
+            return false;
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            return false;
+        }
         if ($this->container['accountId'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
+            return false;
+        }
+        if ($this->container['importId'] === null) {
             return false;
         }
         if ($this->container['type'] === null) {
@@ -342,6 +446,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         }
         $allowedValues = $this->getTypeAllowableValues();
         if (!in_array($this->container['type'], $allowedValues)) {
+            return false;
+        }
+        if ($this->container['parentTransactionId'] === null) {
             return false;
         }
         if ($this->container['accountName'] === null) {
@@ -481,6 +588,39 @@ class HybridTransaction implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets flagColor
+     *
+     * @return string
+     */
+    public function getFlagColor()
+    {
+        return $this->container['flagColor'];
+    }
+
+    /**
+     * Sets flagColor
+     *
+     * @param string $flagColor The transaction flag
+     *
+     * @return $this
+     */
+    public function setFlagColor($flagColor)
+    {
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($flagColor, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'flagColor', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['flagColor'] = $flagColor;
+
+        return $this;
+    }
+
+    /**
      * Gets accountId
      *
      * @return string
@@ -500,6 +640,102 @@ class HybridTransaction implements ModelInterface, ArrayAccess
     public function setAccountId($accountId)
     {
         $this->container['accountId'] = $accountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId transferAccountId
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets importId
+     *
+     * @return string
+     */
+    public function getImportId()
+    {
+        return $this->container['importId'];
+    }
+
+    /**
+     * Sets importId
+     *
+     * @param string $importId If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     *
+     * @return $this
+     */
+    public function setImportId($importId)
+    {
+        $this->container['importId'] = $importId;
 
         return $this;
     }
@@ -533,6 +769,30 @@ class HybridTransaction implements ModelInterface, ArrayAccess
             );
         }
         $this->container['type'] = $type;
+
+        return $this;
+    }
+
+    /**
+     * Gets parentTransactionId
+     *
+     * @return string
+     */
+    public function getParentTransactionId()
+    {
+        return $this->container['parentTransactionId'];
+    }
+
+    /**
+     * Sets parentTransactionId
+     *
+     * @param string $parentTransactionId For subtransaction types, this is the id of the pararent transaction.  For transaction types, this id will be always be null.
+     *
+     * @return $this
+     */
+    public function setParentTransactionId($parentTransactionId)
+    {
+        $this->container['parentTransactionId'] = $parentTransactionId;
 
         return $this;
     }

--- a/src/Model/HybridTransaction.php
+++ b/src/Model/HybridTransaction.php
@@ -60,6 +60,7 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'id' => 'string',
         'date' => '\DateTime',
         'amount' => 'float',
+        'memo' => 'string',
         'cleared' => 'string',
         'approved' => 'bool',
         'flagColor' => 'string',
@@ -70,7 +71,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'importId' => 'string',
         'type' => 'string',
         'parentTransactionId' => 'string',
-        'accountName' => 'string'
+        'accountName' => 'string',
+        'payeeName' => 'string',
+        'categoryName' => 'string'
     ];
 
     /**
@@ -82,6 +85,7 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'id' => 'uuid',
         'date' => 'date',
         'amount' => '1234000',
+        'memo' => null,
         'cleared' => null,
         'approved' => null,
         'flagColor' => null,
@@ -92,7 +96,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'importId' => null,
         'type' => null,
         'parentTransactionId' => 'uuid',
-        'accountName' => null
+        'accountName' => null,
+        'payeeName' => null,
+        'categoryName' => null
     ];
 
     /**
@@ -125,6 +131,7 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'id' => 'id',
         'date' => 'date',
         'amount' => 'amount',
+        'memo' => 'memo',
         'cleared' => 'cleared',
         'approved' => 'approved',
         'flagColor' => 'flag_color',
@@ -135,7 +142,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'importId' => 'import_id',
         'type' => 'type',
         'parentTransactionId' => 'parent_transaction_id',
-        'accountName' => 'account_name'
+        'accountName' => 'account_name',
+        'payeeName' => 'payee_name',
+        'categoryName' => 'category_name'
     ];
 
     /**
@@ -147,6 +156,7 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'id' => 'setId',
         'date' => 'setDate',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
         'flagColor' => 'setFlagColor',
@@ -157,7 +167,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'importId' => 'setImportId',
         'type' => 'setType',
         'parentTransactionId' => 'setParentTransactionId',
-        'accountName' => 'setAccountName'
+        'accountName' => 'setAccountName',
+        'payeeName' => 'setPayeeName',
+        'categoryName' => 'setCategoryName'
     ];
 
     /**
@@ -169,6 +181,7 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'id' => 'getId',
         'date' => 'getDate',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
         'flagColor' => 'getFlagColor',
@@ -179,7 +192,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         'importId' => 'getImportId',
         'type' => 'getType',
         'parentTransactionId' => 'getParentTransactionId',
-        'accountName' => 'getAccountName'
+        'accountName' => 'getAccountName',
+        'payeeName' => 'getPayeeName',
+        'categoryName' => 'getCategoryName'
     ];
 
     /**
@@ -300,6 +315,7 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
         $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
@@ -311,6 +327,8 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['parentTransactionId'] = isset($data['parentTransactionId']) ? $data['parentTransactionId'] : null;
         $this->container['accountName'] = isset($data['accountName']) ? $data['accountName'] : null;
+        $this->container['payeeName'] = isset($data['payeeName']) ? $data['payeeName'] : null;
+        $this->container['categoryName'] = isset($data['categoryName']) ? $data['categoryName'] : null;
     }
 
     /**
@@ -330,6 +348,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         }
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
+        }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
         }
         if ($this->container['cleared'] === null) {
             $invalidProperties[] = "'cleared' can't be null";
@@ -388,6 +409,12 @@ class HybridTransaction implements ModelInterface, ArrayAccess
         if ($this->container['accountName'] === null) {
             $invalidProperties[] = "'accountName' can't be null";
         }
+        if ($this->container['payeeName'] === null) {
+            $invalidProperties[] = "'payeeName' can't be null";
+        }
+        if ($this->container['categoryName'] === null) {
+            $invalidProperties[] = "'categoryName' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -407,6 +434,9 @@ class HybridTransaction implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['memo'] === null) {
             return false;
         }
         if ($this->container['cleared'] === null) {
@@ -452,6 +482,12 @@ class HybridTransaction implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['accountName'] === null) {
+            return false;
+        }
+        if ($this->container['payeeName'] === null) {
+            return false;
+        }
+        if ($this->container['categoryName'] === null) {
             return false;
         }
         return true;
@@ -526,6 +562,30 @@ class HybridTransaction implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }
@@ -817,6 +877,54 @@ class HybridTransaction implements ModelInterface, ArrayAccess
     public function setAccountName($accountName)
     {
         $this->container['accountName'] = $accountName;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeName
+     *
+     * @return string
+     */
+    public function getPayeeName()
+    {
+        return $this->container['payeeName'];
+    }
+
+    /**
+     * Sets payeeName
+     *
+     * @param string $payeeName payeeName
+     *
+     * @return $this
+     */
+    public function setPayeeName($payeeName)
+    {
+        $this->container['payeeName'] = $payeeName;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryName
+     *
+     * @return string
+     */
+    public function getCategoryName()
+    {
+        return $this->container['categoryName'];
+    }
+
+    /**
+     * Sets categoryName
+     *
+     * @param string $categoryName categoryName
+     *
+     * @return $this
+     */
+    public function setCategoryName($categoryName)
+    {
+        $this->container['categoryName'] = $categoryName;
 
         return $this;
     }

--- a/src/Model/MonthDetail.php
+++ b/src/Model/MonthDetail.php
@@ -59,6 +59,8 @@ class MonthDetail implements ModelInterface, ArrayAccess
     protected static $swaggerTypes = [
         'month' => '\DateTime',
         'note' => 'string',
+        'toBeBudgeted' => 'float',
+        'ageOfMoney' => 'float',
         'categories' => '\YNAB\Model\Category[]'
     ];
 
@@ -70,6 +72,8 @@ class MonthDetail implements ModelInterface, ArrayAccess
     protected static $swaggerFormats = [
         'month' => 'date',
         'note' => null,
+        'toBeBudgeted' => '1234000',
+        'ageOfMoney' => null,
         'categories' => null
     ];
 
@@ -102,6 +106,8 @@ class MonthDetail implements ModelInterface, ArrayAccess
     protected static $attributeMap = [
         'month' => 'month',
         'note' => 'note',
+        'toBeBudgeted' => 'to_be_budgeted',
+        'ageOfMoney' => 'age_of_money',
         'categories' => 'categories'
     ];
 
@@ -113,6 +119,8 @@ class MonthDetail implements ModelInterface, ArrayAccess
     protected static $setters = [
         'month' => 'setMonth',
         'note' => 'setNote',
+        'toBeBudgeted' => 'setToBeBudgeted',
+        'ageOfMoney' => 'setAgeOfMoney',
         'categories' => 'setCategories'
     ];
 
@@ -124,6 +132,8 @@ class MonthDetail implements ModelInterface, ArrayAccess
     protected static $getters = [
         'month' => 'getMonth',
         'note' => 'getNote',
+        'toBeBudgeted' => 'getToBeBudgeted',
+        'ageOfMoney' => 'getAgeOfMoney',
         'categories' => 'getCategories'
     ];
 
@@ -189,6 +199,8 @@ class MonthDetail implements ModelInterface, ArrayAccess
     {
         $this->container['month'] = isset($data['month']) ? $data['month'] : null;
         $this->container['note'] = isset($data['note']) ? $data['note'] : null;
+        $this->container['toBeBudgeted'] = isset($data['toBeBudgeted']) ? $data['toBeBudgeted'] : null;
+        $this->container['ageOfMoney'] = isset($data['ageOfMoney']) ? $data['ageOfMoney'] : null;
         $this->container['categories'] = isset($data['categories']) ? $data['categories'] : null;
     }
 
@@ -206,6 +218,12 @@ class MonthDetail implements ModelInterface, ArrayAccess
         }
         if ($this->container['note'] === null) {
             $invalidProperties[] = "'note' can't be null";
+        }
+        if ($this->container['toBeBudgeted'] === null) {
+            $invalidProperties[] = "'toBeBudgeted' can't be null";
+        }
+        if ($this->container['ageOfMoney'] === null) {
+            $invalidProperties[] = "'ageOfMoney' can't be null";
         }
         if ($this->container['categories'] === null) {
             $invalidProperties[] = "'categories' can't be null";
@@ -226,6 +244,12 @@ class MonthDetail implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['note'] === null) {
+            return false;
+        }
+        if ($this->container['toBeBudgeted'] === null) {
+            return false;
+        }
+        if ($this->container['ageOfMoney'] === null) {
             return false;
         }
         if ($this->container['categories'] === null) {
@@ -279,6 +303,54 @@ class MonthDetail implements ModelInterface, ArrayAccess
     public function setNote($note)
     {
         $this->container['note'] = $note;
+
+        return $this;
+    }
+
+    /**
+     * Gets toBeBudgeted
+     *
+     * @return float
+     */
+    public function getToBeBudgeted()
+    {
+        return $this->container['toBeBudgeted'];
+    }
+
+    /**
+     * Sets toBeBudgeted
+     *
+     * @param float $toBeBudgeted The current balance of the account in milliunits format
+     *
+     * @return $this
+     */
+    public function setToBeBudgeted($toBeBudgeted)
+    {
+        $this->container['toBeBudgeted'] = $toBeBudgeted;
+
+        return $this;
+    }
+
+    /**
+     * Gets ageOfMoney
+     *
+     * @return float
+     */
+    public function getAgeOfMoney()
+    {
+        return $this->container['ageOfMoney'];
+    }
+
+    /**
+     * Sets ageOfMoney
+     *
+     * @param float $ageOfMoney ageOfMoney
+     *
+     * @return $this
+     */
+    public function setAgeOfMoney($ageOfMoney)
+    {
+        $this->container['ageOfMoney'] = $ageOfMoney;
 
         return $this;
     }

--- a/src/Model/MonthDetail.php
+++ b/src/Model/MonthDetail.php
@@ -58,6 +58,7 @@ class MonthDetail implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'month' => '\DateTime',
+        'note' => 'string',
         'categories' => '\YNAB\Model\Category[]'
     ];
 
@@ -68,6 +69,7 @@ class MonthDetail implements ModelInterface, ArrayAccess
       */
     protected static $swaggerFormats = [
         'month' => 'date',
+        'note' => null,
         'categories' => null
     ];
 
@@ -99,6 +101,7 @@ class MonthDetail implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'month' => 'month',
+        'note' => 'note',
         'categories' => 'categories'
     ];
 
@@ -109,6 +112,7 @@ class MonthDetail implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'month' => 'setMonth',
+        'note' => 'setNote',
         'categories' => 'setCategories'
     ];
 
@@ -119,6 +123,7 @@ class MonthDetail implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'month' => 'getMonth',
+        'note' => 'getNote',
         'categories' => 'getCategories'
     ];
 
@@ -183,6 +188,7 @@ class MonthDetail implements ModelInterface, ArrayAccess
     public function __construct(array $data = null)
     {
         $this->container['month'] = isset($data['month']) ? $data['month'] : null;
+        $this->container['note'] = isset($data['note']) ? $data['note'] : null;
         $this->container['categories'] = isset($data['categories']) ? $data['categories'] : null;
     }
 
@@ -197,6 +203,9 @@ class MonthDetail implements ModelInterface, ArrayAccess
 
         if ($this->container['month'] === null) {
             $invalidProperties[] = "'month' can't be null";
+        }
+        if ($this->container['note'] === null) {
+            $invalidProperties[] = "'note' can't be null";
         }
         if ($this->container['categories'] === null) {
             $invalidProperties[] = "'categories' can't be null";
@@ -214,6 +223,9 @@ class MonthDetail implements ModelInterface, ArrayAccess
     {
 
         if ($this->container['month'] === null) {
+            return false;
+        }
+        if ($this->container['note'] === null) {
             return false;
         }
         if ($this->container['categories'] === null) {
@@ -243,6 +255,30 @@ class MonthDetail implements ModelInterface, ArrayAccess
     public function setMonth($month)
     {
         $this->container['month'] = $month;
+
+        return $this;
+    }
+
+    /**
+     * Gets note
+     *
+     * @return string
+     */
+    public function getNote()
+    {
+        return $this->container['note'];
+    }
+
+    /**
+     * Sets note
+     *
+     * @param string $note note
+     *
+     * @return $this
+     */
+    public function setNote($note)
+    {
+        $this->container['note'] = $note;
 
         return $this;
     }

--- a/src/Model/MonthSummary.php
+++ b/src/Model/MonthSummary.php
@@ -57,7 +57,8 @@ class MonthSummary implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'month' => '\DateTime'
+        'month' => '\DateTime',
+        'note' => 'string'
     ];
 
     /**
@@ -66,7 +67,8 @@ class MonthSummary implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'month' => 'date'
+        'month' => 'date',
+        'note' => null
     ];
 
     /**
@@ -96,7 +98,8 @@ class MonthSummary implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'month' => 'month'
+        'month' => 'month',
+        'note' => 'note'
     ];
 
     /**
@@ -105,7 +108,8 @@ class MonthSummary implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'month' => 'setMonth'
+        'month' => 'setMonth',
+        'note' => 'setNote'
     ];
 
     /**
@@ -114,7 +118,8 @@ class MonthSummary implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'month' => 'getMonth'
+        'month' => 'getMonth',
+        'note' => 'getNote'
     ];
 
     /**
@@ -178,6 +183,7 @@ class MonthSummary implements ModelInterface, ArrayAccess
     public function __construct(array $data = null)
     {
         $this->container['month'] = isset($data['month']) ? $data['month'] : null;
+        $this->container['note'] = isset($data['note']) ? $data['note'] : null;
     }
 
     /**
@@ -192,6 +198,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
         if ($this->container['month'] === null) {
             $invalidProperties[] = "'month' can't be null";
         }
+        if ($this->container['note'] === null) {
+            $invalidProperties[] = "'note' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -205,6 +214,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
     {
 
         if ($this->container['month'] === null) {
+            return false;
+        }
+        if ($this->container['note'] === null) {
             return false;
         }
         return true;
@@ -231,6 +243,30 @@ class MonthSummary implements ModelInterface, ArrayAccess
     public function setMonth($month)
     {
         $this->container['month'] = $month;
+
+        return $this;
+    }
+
+    /**
+     * Gets note
+     *
+     * @return string
+     */
+    public function getNote()
+    {
+        return $this->container['note'];
+    }
+
+    /**
+     * Sets note
+     *
+     * @param string $note note
+     *
+     * @return $this
+     */
+    public function setNote($note)
+    {
+        $this->container['note'] = $note;
 
         return $this;
     }

--- a/src/Model/MonthSummary.php
+++ b/src/Model/MonthSummary.php
@@ -58,7 +58,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'month' => '\DateTime',
-        'note' => 'string'
+        'note' => 'string',
+        'toBeBudgeted' => 'float',
+        'ageOfMoney' => 'float'
     ];
 
     /**
@@ -68,7 +70,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
       */
     protected static $swaggerFormats = [
         'month' => 'date',
-        'note' => null
+        'note' => null,
+        'toBeBudgeted' => '1234000',
+        'ageOfMoney' => null
     ];
 
     /**
@@ -99,7 +103,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'month' => 'month',
-        'note' => 'note'
+        'note' => 'note',
+        'toBeBudgeted' => 'to_be_budgeted',
+        'ageOfMoney' => 'age_of_money'
     ];
 
     /**
@@ -109,7 +115,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'month' => 'setMonth',
-        'note' => 'setNote'
+        'note' => 'setNote',
+        'toBeBudgeted' => 'setToBeBudgeted',
+        'ageOfMoney' => 'setAgeOfMoney'
     ];
 
     /**
@@ -119,7 +127,9 @@ class MonthSummary implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'month' => 'getMonth',
-        'note' => 'getNote'
+        'note' => 'getNote',
+        'toBeBudgeted' => 'getToBeBudgeted',
+        'ageOfMoney' => 'getAgeOfMoney'
     ];
 
     /**
@@ -184,6 +194,8 @@ class MonthSummary implements ModelInterface, ArrayAccess
     {
         $this->container['month'] = isset($data['month']) ? $data['month'] : null;
         $this->container['note'] = isset($data['note']) ? $data['note'] : null;
+        $this->container['toBeBudgeted'] = isset($data['toBeBudgeted']) ? $data['toBeBudgeted'] : null;
+        $this->container['ageOfMoney'] = isset($data['ageOfMoney']) ? $data['ageOfMoney'] : null;
     }
 
     /**
@@ -201,6 +213,12 @@ class MonthSummary implements ModelInterface, ArrayAccess
         if ($this->container['note'] === null) {
             $invalidProperties[] = "'note' can't be null";
         }
+        if ($this->container['toBeBudgeted'] === null) {
+            $invalidProperties[] = "'toBeBudgeted' can't be null";
+        }
+        if ($this->container['ageOfMoney'] === null) {
+            $invalidProperties[] = "'ageOfMoney' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -217,6 +235,12 @@ class MonthSummary implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['note'] === null) {
+            return false;
+        }
+        if ($this->container['toBeBudgeted'] === null) {
+            return false;
+        }
+        if ($this->container['ageOfMoney'] === null) {
             return false;
         }
         return true;
@@ -267,6 +291,54 @@ class MonthSummary implements ModelInterface, ArrayAccess
     public function setNote($note)
     {
         $this->container['note'] = $note;
+
+        return $this;
+    }
+
+    /**
+     * Gets toBeBudgeted
+     *
+     * @return float
+     */
+    public function getToBeBudgeted()
+    {
+        return $this->container['toBeBudgeted'];
+    }
+
+    /**
+     * Sets toBeBudgeted
+     *
+     * @param float $toBeBudgeted The current balance of the account in milliunits format
+     *
+     * @return $this
+     */
+    public function setToBeBudgeted($toBeBudgeted)
+    {
+        $this->container['toBeBudgeted'] = $toBeBudgeted;
+
+        return $this;
+    }
+
+    /**
+     * Gets ageOfMoney
+     *
+     * @return float
+     */
+    public function getAgeOfMoney()
+    {
+        return $this->container['ageOfMoney'];
+    }
+
+    /**
+     * Sets ageOfMoney
+     *
+     * @param float $ageOfMoney ageOfMoney
+     *
+     * @return $this
+     */
+    public function setAgeOfMoney($ageOfMoney)
+    {
+        $this->container['ageOfMoney'] = $ageOfMoney;
 
         return $this;
     }

--- a/src/Model/Payee.php
+++ b/src/Model/Payee.php
@@ -58,7 +58,8 @@ class Payee implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'id' => 'string',
-        'name' => 'string'
+        'name' => 'string',
+        'transferAccountId' => 'string'
     ];
 
     /**
@@ -68,7 +69,8 @@ class Payee implements ModelInterface, ArrayAccess
       */
     protected static $swaggerFormats = [
         'id' => 'uuid',
-        'name' => null
+        'name' => null,
+        'transferAccountId' => null
     ];
 
     /**
@@ -99,7 +101,8 @@ class Payee implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'id' => 'id',
-        'name' => 'name'
+        'name' => 'name',
+        'transferAccountId' => 'transfer_account_id'
     ];
 
     /**
@@ -109,7 +112,8 @@ class Payee implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'id' => 'setId',
-        'name' => 'setName'
+        'name' => 'setName',
+        'transferAccountId' => 'setTransferAccountId'
     ];
 
     /**
@@ -119,7 +123,8 @@ class Payee implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'id' => 'getId',
-        'name' => 'getName'
+        'name' => 'getName',
+        'transferAccountId' => 'getTransferAccountId'
     ];
 
     /**
@@ -184,6 +189,7 @@ class Payee implements ModelInterface, ArrayAccess
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
     }
 
     /**
@@ -201,6 +207,9 @@ class Payee implements ModelInterface, ArrayAccess
         if ($this->container['name'] === null) {
             $invalidProperties[] = "'name' can't be null";
         }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -217,6 +226,9 @@ class Payee implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['name'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
             return false;
         }
         return true;
@@ -267,6 +279,30 @@ class Payee implements ModelInterface, ArrayAccess
     public function setName($name)
     {
         $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId If a transfer payee, the account_id to which this payee transfers to
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
 
         return $this;
     }

--- a/src/Model/PayeeLocation.php
+++ b/src/Model/PayeeLocation.php
@@ -58,7 +58,9 @@ class PayeeLocation implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'id' => 'string',
-        'payeeId' => 'string'
+        'payeeId' => 'string',
+        'latitude' => 'string',
+        'longitude' => 'string'
     ];
 
     /**
@@ -68,7 +70,9 @@ class PayeeLocation implements ModelInterface, ArrayAccess
       */
     protected static $swaggerFormats = [
         'id' => 'uuid',
-        'payeeId' => 'uuid'
+        'payeeId' => 'uuid',
+        'latitude' => null,
+        'longitude' => null
     ];
 
     /**
@@ -99,7 +103,9 @@ class PayeeLocation implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'id' => 'id',
-        'payeeId' => 'payee_id'
+        'payeeId' => 'payee_id',
+        'latitude' => 'latitude',
+        'longitude' => 'longitude'
     ];
 
     /**
@@ -109,7 +115,9 @@ class PayeeLocation implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'id' => 'setId',
-        'payeeId' => 'setPayeeId'
+        'payeeId' => 'setPayeeId',
+        'latitude' => 'setLatitude',
+        'longitude' => 'setLongitude'
     ];
 
     /**
@@ -119,7 +127,9 @@ class PayeeLocation implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'id' => 'getId',
-        'payeeId' => 'getPayeeId'
+        'payeeId' => 'getPayeeId',
+        'latitude' => 'getLatitude',
+        'longitude' => 'getLongitude'
     ];
 
     /**
@@ -184,6 +194,8 @@ class PayeeLocation implements ModelInterface, ArrayAccess
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['latitude'] = isset($data['latitude']) ? $data['latitude'] : null;
+        $this->container['longitude'] = isset($data['longitude']) ? $data['longitude'] : null;
     }
 
     /**
@@ -201,6 +213,12 @@ class PayeeLocation implements ModelInterface, ArrayAccess
         if ($this->container['payeeId'] === null) {
             $invalidProperties[] = "'payeeId' can't be null";
         }
+        if ($this->container['latitude'] === null) {
+            $invalidProperties[] = "'latitude' can't be null";
+        }
+        if ($this->container['longitude'] === null) {
+            $invalidProperties[] = "'longitude' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -217,6 +235,12 @@ class PayeeLocation implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['latitude'] === null) {
+            return false;
+        }
+        if ($this->container['longitude'] === null) {
             return false;
         }
         return true;
@@ -267,6 +291,54 @@ class PayeeLocation implements ModelInterface, ArrayAccess
     public function setPayeeId($payeeId)
     {
         $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets latitude
+     *
+     * @return string
+     */
+    public function getLatitude()
+    {
+        return $this->container['latitude'];
+    }
+
+    /**
+     * Sets latitude
+     *
+     * @param string $latitude latitude
+     *
+     * @return $this
+     */
+    public function setLatitude($latitude)
+    {
+        $this->container['latitude'] = $latitude;
+
+        return $this;
+    }
+
+    /**
+     * Gets longitude
+     *
+     * @return string
+     */
+    public function getLongitude()
+    {
+        return $this->container['longitude'];
+    }
+
+    /**
+     * Sets longitude
+     *
+     * @param string $longitude longitude
+     *
+     * @return $this
+     */
+    public function setLongitude($longitude)
+    {
+        $this->container['longitude'] = $longitude;
 
         return $this;
     }

--- a/src/Model/SaveTransaction.php
+++ b/src/Model/SaveTransaction.php
@@ -63,6 +63,7 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'payeeId' => 'string',
         'payeeName' => 'string',
         'categoryId' => 'string',
+        'memo' => 'string',
         'cleared' => 'string',
         'approved' => 'bool',
         'flagColor' => 'string',
@@ -81,6 +82,7 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'payeeId' => 'uuid',
         'payeeName' => null,
         'categoryId' => 'uuid',
+        'memo' => null,
         'cleared' => null,
         'approved' => null,
         'flagColor' => null,
@@ -120,6 +122,7 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'payeeId' => 'payee_id',
         'payeeName' => 'payee_name',
         'categoryId' => 'category_id',
+        'memo' => 'memo',
         'cleared' => 'cleared',
         'approved' => 'approved',
         'flagColor' => 'flag_color',
@@ -138,6 +141,7 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'payeeId' => 'setPayeeId',
         'payeeName' => 'setPayeeName',
         'categoryId' => 'setCategoryId',
+        'memo' => 'setMemo',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
         'flagColor' => 'setFlagColor',
@@ -156,6 +160,7 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'payeeId' => 'getPayeeId',
         'payeeName' => 'getPayeeName',
         'categoryId' => 'getCategoryId',
+        'memo' => 'getMemo',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
         'flagColor' => 'getFlagColor',
@@ -268,6 +273,7 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
         $this->container['payeeName'] = isset($data['payeeName']) ? $data['payeeName'] : null;
         $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
         $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
@@ -481,6 +487,30 @@ class SaveTransaction implements ModelInterface, ArrayAccess
     public function setCategoryId($categoryId)
     {
         $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }

--- a/src/Model/SaveTransaction.php
+++ b/src/Model/SaveTransaction.php
@@ -60,8 +60,13 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'accountId' => 'string',
         'date' => '\DateTime',
         'amount' => 'float',
+        'payeeId' => 'string',
+        'payeeName' => 'string',
+        'categoryId' => 'string',
         'cleared' => 'string',
-        'approved' => 'bool'
+        'approved' => 'bool',
+        'flagColor' => 'string',
+        'importId' => 'string'
     ];
 
     /**
@@ -73,8 +78,13 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'accountId' => 'uuid',
         'date' => 'date',
         'amount' => '1234000',
+        'payeeId' => 'uuid',
+        'payeeName' => null,
+        'categoryId' => 'uuid',
         'cleared' => null,
-        'approved' => null
+        'approved' => null,
+        'flagColor' => null,
+        'importId' => null
     ];
 
     /**
@@ -107,8 +117,13 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'accountId' => 'account_id',
         'date' => 'date',
         'amount' => 'amount',
+        'payeeId' => 'payee_id',
+        'payeeName' => 'payee_name',
+        'categoryId' => 'category_id',
         'cleared' => 'cleared',
-        'approved' => 'approved'
+        'approved' => 'approved',
+        'flagColor' => 'flag_color',
+        'importId' => 'import_id'
     ];
 
     /**
@@ -120,8 +135,13 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'accountId' => 'setAccountId',
         'date' => 'setDate',
         'amount' => 'setAmount',
+        'payeeId' => 'setPayeeId',
+        'payeeName' => 'setPayeeName',
+        'categoryId' => 'setCategoryId',
         'cleared' => 'setCleared',
-        'approved' => 'setApproved'
+        'approved' => 'setApproved',
+        'flagColor' => 'setFlagColor',
+        'importId' => 'setImportId'
     ];
 
     /**
@@ -133,8 +153,13 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         'accountId' => 'getAccountId',
         'date' => 'getDate',
         'amount' => 'getAmount',
+        'payeeId' => 'getPayeeId',
+        'payeeName' => 'getPayeeName',
+        'categoryId' => 'getCategoryId',
         'cleared' => 'getCleared',
-        'approved' => 'getApproved'
+        'approved' => 'getApproved',
+        'flagColor' => 'getFlagColor',
+        'importId' => 'getImportId'
     ];
 
     /**
@@ -181,6 +206,12 @@ class SaveTransaction implements ModelInterface, ArrayAccess
     const CLEARED_CLEARED = 'cleared';
     const CLEARED_UNCLEARED = 'uncleared';
     const CLEARED_RECONCILED = 'reconciled';
+    const FLAG_COLOR_RED = 'red';
+    const FLAG_COLOR_ORANGE = 'orange';
+    const FLAG_COLOR_YELLOW = 'yellow';
+    const FLAG_COLOR_GREEN = 'green';
+    const FLAG_COLOR_BLUE = 'blue';
+    const FLAG_COLOR_PURPLE = 'purple';
     
 
     
@@ -195,6 +226,23 @@ class SaveTransaction implements ModelInterface, ArrayAccess
             self::CLEARED_CLEARED,
             self::CLEARED_UNCLEARED,
             self::CLEARED_RECONCILED,
+        ];
+    }
+    
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getFlagColorAllowableValues()
+    {
+        return [
+            self::FLAG_COLOR_RED,
+            self::FLAG_COLOR_ORANGE,
+            self::FLAG_COLOR_YELLOW,
+            self::FLAG_COLOR_GREEN,
+            self::FLAG_COLOR_BLUE,
+            self::FLAG_COLOR_PURPLE,
         ];
     }
     
@@ -217,8 +265,13 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['payeeName'] = isset($data['payeeName']) ? $data['payeeName'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
+        $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
+        $this->container['importId'] = isset($data['importId']) ? $data['importId'] : null;
     }
 
     /**
@@ -247,6 +300,14 @@ class SaveTransaction implements ModelInterface, ArrayAccess
             );
         }
 
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'flagColor', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
         return $invalidProperties;
     }
 
@@ -270,6 +331,10 @@ class SaveTransaction implements ModelInterface, ArrayAccess
         }
         $allowedValues = $this->getClearedAllowableValues();
         if (!in_array($this->container['cleared'], $allowedValues)) {
+            return false;
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
             return false;
         }
         return true;
@@ -349,6 +414,78 @@ class SaveTransaction implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied.
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeName
+     *
+     * @return string
+     */
+    public function getPayeeName()
+    {
+        return $this->container['payeeName'];
+    }
+
+    /**
+     * Sets payeeName
+     *
+     * @param string $payeeName The payee name.  If a payee_name value is provided and payee_id is not included or has a null value, payee_name will be used to create or use an existing payee.
+     *
+     * @return $this
+     */
+    public function setPayeeName($payeeName)
+    {
+        $this->container['payeeName'] = $payeeName;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied.
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
      * Gets cleared
      *
      * @return string
@@ -401,6 +538,63 @@ class SaveTransaction implements ModelInterface, ArrayAccess
     public function setApproved($approved)
     {
         $this->container['approved'] = $approved;
+
+        return $this;
+    }
+
+    /**
+     * Gets flagColor
+     *
+     * @return string
+     */
+    public function getFlagColor()
+    {
+        return $this->container['flagColor'];
+    }
+
+    /**
+     * Sets flagColor
+     *
+     * @param string $flagColor The transaction flag
+     *
+     * @return $this
+     */
+    public function setFlagColor($flagColor)
+    {
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!is_null($flagColor) && !in_array($flagColor, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'flagColor', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['flagColor'] = $flagColor;
+
+        return $this;
+    }
+
+    /**
+     * Gets importId
+     *
+     * @return string
+     */
+    public function getImportId()
+    {
+        return $this->container['importId'];
+    }
+
+    /**
+     * Sets importId
+     *
+     * @param string $importId If specified for a new transaction, the transaction will be treated as Imported and assigned this import_id.  If another transaction on the same account with this same import_id is later attempted to be created, it will be skipped to prevent duplication.  Transactions imported through File Based Import or Direct Import and not through the API, are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.  If import_id is specified as null, the transaction will be treated as a user entered transaction.
+     *
+     * @return $this
+     */
+    public function setImportId($importId)
+    {
+        $this->container['importId'] = $importId;
 
         return $this;
     }

--- a/src/Model/ScheduledSubTransaction.php
+++ b/src/Model/ScheduledSubTransaction.php
@@ -60,6 +60,7 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         'id' => 'string',
         'scheduledTransactionId' => 'string',
         'amount' => 'float',
+        'memo' => 'string',
         'payeeId' => 'string',
         'categoryId' => 'string',
         'transferAccountId' => 'string'
@@ -74,6 +75,7 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         'id' => 'uuid',
         'scheduledTransactionId' => 'uuid',
         'amount' => '1234000',
+        'memo' => null,
         'payeeId' => 'uuid',
         'categoryId' => 'uuid',
         'transferAccountId' => 'uuid'
@@ -109,6 +111,7 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         'id' => 'id',
         'scheduledTransactionId' => 'scheduled_transaction_id',
         'amount' => 'amount',
+        'memo' => 'memo',
         'payeeId' => 'payee_id',
         'categoryId' => 'category_id',
         'transferAccountId' => 'transfer_account_id'
@@ -123,6 +126,7 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         'id' => 'setId',
         'scheduledTransactionId' => 'setScheduledTransactionId',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'payeeId' => 'setPayeeId',
         'categoryId' => 'setCategoryId',
         'transferAccountId' => 'setTransferAccountId'
@@ -137,6 +141,7 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         'id' => 'getId',
         'scheduledTransactionId' => 'getScheduledTransactionId',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'payeeId' => 'getPayeeId',
         'categoryId' => 'getCategoryId',
         'transferAccountId' => 'getTransferAccountId'
@@ -205,6 +210,7 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['scheduledTransactionId'] = isset($data['scheduledTransactionId']) ? $data['scheduledTransactionId'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
         $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
         $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
@@ -227,6 +233,9 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         }
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
+        }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
         }
         if ($this->container['payeeId'] === null) {
             $invalidProperties[] = "'payeeId' can't be null";
@@ -256,6 +265,9 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['memo'] === null) {
             return false;
         }
         if ($this->container['payeeId'] === null) {
@@ -339,6 +351,30 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }

--- a/src/Model/ScheduledSubTransaction.php
+++ b/src/Model/ScheduledSubTransaction.php
@@ -59,7 +59,10 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     protected static $swaggerTypes = [
         'id' => 'string',
         'scheduledTransactionId' => 'string',
-        'amount' => 'float'
+        'amount' => 'float',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string'
     ];
 
     /**
@@ -70,7 +73,10 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     protected static $swaggerFormats = [
         'id' => 'uuid',
         'scheduledTransactionId' => 'uuid',
-        'amount' => '1234000'
+        'amount' => '1234000',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid'
     ];
 
     /**
@@ -102,7 +108,10 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     protected static $attributeMap = [
         'id' => 'id',
         'scheduledTransactionId' => 'scheduled_transaction_id',
-        'amount' => 'amount'
+        'amount' => 'amount',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id'
     ];
 
     /**
@@ -113,7 +122,10 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     protected static $setters = [
         'id' => 'setId',
         'scheduledTransactionId' => 'setScheduledTransactionId',
-        'amount' => 'setAmount'
+        'amount' => 'setAmount',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId'
     ];
 
     /**
@@ -124,7 +136,10 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     protected static $getters = [
         'id' => 'getId',
         'scheduledTransactionId' => 'getScheduledTransactionId',
-        'amount' => 'getAmount'
+        'amount' => 'getAmount',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId'
     ];
 
     /**
@@ -190,6 +205,9 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['scheduledTransactionId'] = isset($data['scheduledTransactionId']) ? $data['scheduledTransactionId'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
     }
 
     /**
@@ -210,6 +228,15 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
         }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -229,6 +256,15 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
             return false;
         }
         return true;
@@ -303,6 +339,78 @@ class ScheduledSubTransaction implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId If a transfer, the account_id which the scheduled sub transaction transfers to
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
 
         return $this;
     }

--- a/src/Model/ScheduledTransactionDetail.php
+++ b/src/Model/ScheduledTransactionDetail.php
@@ -62,7 +62,11 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => '\DateTime',
         'frequency' => 'string',
         'amount' => 'float',
+        'flagColor' => 'string',
         'accountId' => 'string',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string',
         'accountName' => 'string',
         'subtransactions' => '\YNAB\Model\ScheduledSubTransaction[]'
     ];
@@ -78,7 +82,11 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'date',
         'frequency' => null,
         'amount' => '1234000',
+        'flagColor' => null,
         'accountId' => 'uuid',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid',
         'accountName' => null,
         'subtransactions' => null
     ];
@@ -115,7 +123,11 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'date_next',
         'frequency' => 'frequency',
         'amount' => 'amount',
+        'flagColor' => 'flag_color',
         'accountId' => 'account_id',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id',
         'accountName' => 'account_name',
         'subtransactions' => 'subtransactions'
     ];
@@ -131,7 +143,11 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'setDateNext',
         'frequency' => 'setFrequency',
         'amount' => 'setAmount',
+        'flagColor' => 'setFlagColor',
         'accountId' => 'setAccountId',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId',
         'accountName' => 'setAccountName',
         'subtransactions' => 'setSubtransactions'
     ];
@@ -147,7 +163,11 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'getDateNext',
         'frequency' => 'getFrequency',
         'amount' => 'getAmount',
+        'flagColor' => 'getFlagColor',
         'accountId' => 'getAccountId',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId',
         'accountName' => 'getAccountName',
         'subtransactions' => 'getSubtransactions'
     ];
@@ -206,6 +226,12 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
     const FREQUENCY_TWICE_A_YEAR = 'twiceAYear';
     const FREQUENCY_YEARLY = 'yearly';
     const FREQUENCY_EVERY_OTHER_YEAR = 'everyOtherYear';
+    const FLAG_COLOR_RED = 'red';
+    const FLAG_COLOR_ORANGE = 'orange';
+    const FLAG_COLOR_YELLOW = 'yellow';
+    const FLAG_COLOR_GREEN = 'green';
+    const FLAG_COLOR_BLUE = 'blue';
+    const FLAG_COLOR_PURPLE = 'purple';
     
 
     
@@ -233,6 +259,23 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         ];
     }
     
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getFlagColorAllowableValues()
+    {
+        return [
+            self::FLAG_COLOR_RED,
+            self::FLAG_COLOR_ORANGE,
+            self::FLAG_COLOR_YELLOW,
+            self::FLAG_COLOR_GREEN,
+            self::FLAG_COLOR_BLUE,
+            self::FLAG_COLOR_PURPLE,
+        ];
+    }
+    
 
     /**
      * Associative array for storing property values
@@ -254,7 +297,11 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         $this->container['dateNext'] = isset($data['dateNext']) ? $data['dateNext'] : null;
         $this->container['frequency'] = isset($data['frequency']) ? $data['frequency'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
         $this->container['accountName'] = isset($data['accountName']) ? $data['accountName'] : null;
         $this->container['subtransactions'] = isset($data['subtransactions']) ? $data['subtransactions'] : null;
     }
@@ -291,8 +338,28 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
         }
+        if ($this->container['flagColor'] === null) {
+            $invalidProperties[] = "'flagColor' can't be null";
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'flagColor', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
         if ($this->container['accountId'] === null) {
             $invalidProperties[] = "'accountId' can't be null";
+        }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
         }
         if ($this->container['accountName'] === null) {
             $invalidProperties[] = "'accountName' can't be null";
@@ -331,7 +398,23 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
+        if ($this->container['flagColor'] === null) {
+            return false;
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            return false;
+        }
         if ($this->container['accountId'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
             return false;
         }
         if ($this->container['accountName'] === null) {
@@ -474,6 +557,39 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets flagColor
+     *
+     * @return string
+     */
+    public function getFlagColor()
+    {
+        return $this->container['flagColor'];
+    }
+
+    /**
+     * Sets flagColor
+     *
+     * @param string $flagColor The scheduled transaction flag
+     *
+     * @return $this
+     */
+    public function setFlagColor($flagColor)
+    {
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($flagColor, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'flagColor', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['flagColor'] = $flagColor;
+
+        return $this;
+    }
+
+    /**
      * Gets accountId
      *
      * @return string
@@ -493,6 +609,78 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
     public function setAccountId($accountId)
     {
         $this->container['accountId'] = $accountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId If a transfer, the account_id which the scheduled transaction transfers to
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
 
         return $this;
     }

--- a/src/Model/ScheduledTransactionDetail.php
+++ b/src/Model/ScheduledTransactionDetail.php
@@ -62,12 +62,15 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => '\DateTime',
         'frequency' => 'string',
         'amount' => 'float',
+        'memo' => 'string',
         'flagColor' => 'string',
         'accountId' => 'string',
         'payeeId' => 'string',
         'categoryId' => 'string',
         'transferAccountId' => 'string',
         'accountName' => 'string',
+        'payeeName' => 'string',
+        'categoryName' => 'string',
         'subtransactions' => '\YNAB\Model\ScheduledSubTransaction[]'
     ];
 
@@ -82,12 +85,15 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'date',
         'frequency' => null,
         'amount' => '1234000',
+        'memo' => null,
         'flagColor' => null,
         'accountId' => 'uuid',
         'payeeId' => 'uuid',
         'categoryId' => 'uuid',
         'transferAccountId' => 'uuid',
         'accountName' => null,
+        'payeeName' => null,
+        'categoryName' => null,
         'subtransactions' => null
     ];
 
@@ -123,12 +129,15 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'date_next',
         'frequency' => 'frequency',
         'amount' => 'amount',
+        'memo' => 'memo',
         'flagColor' => 'flag_color',
         'accountId' => 'account_id',
         'payeeId' => 'payee_id',
         'categoryId' => 'category_id',
         'transferAccountId' => 'transfer_account_id',
         'accountName' => 'account_name',
+        'payeeName' => 'payee_name',
+        'categoryName' => 'category_name',
         'subtransactions' => 'subtransactions'
     ];
 
@@ -143,12 +152,15 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'setDateNext',
         'frequency' => 'setFrequency',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'flagColor' => 'setFlagColor',
         'accountId' => 'setAccountId',
         'payeeId' => 'setPayeeId',
         'categoryId' => 'setCategoryId',
         'transferAccountId' => 'setTransferAccountId',
         'accountName' => 'setAccountName',
+        'payeeName' => 'setPayeeName',
+        'categoryName' => 'setCategoryName',
         'subtransactions' => 'setSubtransactions'
     ];
 
@@ -163,12 +175,15 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         'dateNext' => 'getDateNext',
         'frequency' => 'getFrequency',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'flagColor' => 'getFlagColor',
         'accountId' => 'getAccountId',
         'payeeId' => 'getPayeeId',
         'categoryId' => 'getCategoryId',
         'transferAccountId' => 'getTransferAccountId',
         'accountName' => 'getAccountName',
+        'payeeName' => 'getPayeeName',
+        'categoryName' => 'getCategoryName',
         'subtransactions' => 'getSubtransactions'
     ];
 
@@ -297,12 +312,15 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         $this->container['dateNext'] = isset($data['dateNext']) ? $data['dateNext'] : null;
         $this->container['frequency'] = isset($data['frequency']) ? $data['frequency'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
         $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
         $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
         $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
         $this->container['accountName'] = isset($data['accountName']) ? $data['accountName'] : null;
+        $this->container['payeeName'] = isset($data['payeeName']) ? $data['payeeName'] : null;
+        $this->container['categoryName'] = isset($data['categoryName']) ? $data['categoryName'] : null;
         $this->container['subtransactions'] = isset($data['subtransactions']) ? $data['subtransactions'] : null;
     }
 
@@ -338,6 +356,9 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
         }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
+        }
         if ($this->container['flagColor'] === null) {
             $invalidProperties[] = "'flagColor' can't be null";
         }
@@ -363,6 +384,12 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         }
         if ($this->container['accountName'] === null) {
             $invalidProperties[] = "'accountName' can't be null";
+        }
+        if ($this->container['payeeName'] === null) {
+            $invalidProperties[] = "'payeeName' can't be null";
+        }
+        if ($this->container['categoryName'] === null) {
+            $invalidProperties[] = "'categoryName' can't be null";
         }
         if ($this->container['subtransactions'] === null) {
             $invalidProperties[] = "'subtransactions' can't be null";
@@ -398,6 +425,9 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
+        if ($this->container['memo'] === null) {
+            return false;
+        }
         if ($this->container['flagColor'] === null) {
             return false;
         }
@@ -418,6 +448,12 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['accountName'] === null) {
+            return false;
+        }
+        if ($this->container['payeeName'] === null) {
+            return false;
+        }
+        if ($this->container['categoryName'] === null) {
             return false;
         }
         if ($this->container['subtransactions'] === null) {
@@ -552,6 +588,30 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }
@@ -705,6 +765,54 @@ class ScheduledTransactionDetail implements ModelInterface, ArrayAccess
     public function setAccountName($accountName)
     {
         $this->container['accountName'] = $accountName;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeName
+     *
+     * @return string
+     */
+    public function getPayeeName()
+    {
+        return $this->container['payeeName'];
+    }
+
+    /**
+     * Sets payeeName
+     *
+     * @param string $payeeName payeeName
+     *
+     * @return $this
+     */
+    public function setPayeeName($payeeName)
+    {
+        $this->container['payeeName'] = $payeeName;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryName
+     *
+     * @return string
+     */
+    public function getCategoryName()
+    {
+        return $this->container['categoryName'];
+    }
+
+    /**
+     * Sets categoryName
+     *
+     * @param string $categoryName categoryName
+     *
+     * @return $this
+     */
+    public function setCategoryName($categoryName)
+    {
+        $this->container['categoryName'] = $categoryName;
 
         return $this;
     }

--- a/src/Model/ScheduledTransactionSummary.php
+++ b/src/Model/ScheduledTransactionSummary.php
@@ -62,6 +62,7 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => '\DateTime',
         'frequency' => 'string',
         'amount' => 'float',
+        'memo' => 'string',
         'flagColor' => 'string',
         'accountId' => 'string',
         'payeeId' => 'string',
@@ -80,6 +81,7 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'date',
         'frequency' => null,
         'amount' => '1234000',
+        'memo' => null,
         'flagColor' => null,
         'accountId' => 'uuid',
         'payeeId' => 'uuid',
@@ -119,6 +121,7 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'date_next',
         'frequency' => 'frequency',
         'amount' => 'amount',
+        'memo' => 'memo',
         'flagColor' => 'flag_color',
         'accountId' => 'account_id',
         'payeeId' => 'payee_id',
@@ -137,6 +140,7 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'setDateNext',
         'frequency' => 'setFrequency',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'flagColor' => 'setFlagColor',
         'accountId' => 'setAccountId',
         'payeeId' => 'setPayeeId',
@@ -155,6 +159,7 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'getDateNext',
         'frequency' => 'getFrequency',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'flagColor' => 'getFlagColor',
         'accountId' => 'getAccountId',
         'payeeId' => 'getPayeeId',
@@ -287,6 +292,7 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         $this->container['dateNext'] = isset($data['dateNext']) ? $data['dateNext'] : null;
         $this->container['frequency'] = isset($data['frequency']) ? $data['frequency'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
         $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
@@ -325,6 +331,9 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
 
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
+        }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
         }
         if ($this->container['flagColor'] === null) {
             $invalidProperties[] = "'flagColor' can't be null";
@@ -378,6 +387,9 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['memo'] === null) {
             return false;
         }
         if ($this->container['flagColor'] === null) {
@@ -528,6 +540,30 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }

--- a/src/Model/ScheduledTransactionSummary.php
+++ b/src/Model/ScheduledTransactionSummary.php
@@ -62,7 +62,11 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => '\DateTime',
         'frequency' => 'string',
         'amount' => 'float',
-        'accountId' => 'string'
+        'flagColor' => 'string',
+        'accountId' => 'string',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string'
     ];
 
     /**
@@ -76,7 +80,11 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'date',
         'frequency' => null,
         'amount' => '1234000',
-        'accountId' => 'uuid'
+        'flagColor' => null,
+        'accountId' => 'uuid',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid'
     ];
 
     /**
@@ -111,7 +119,11 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'date_next',
         'frequency' => 'frequency',
         'amount' => 'amount',
-        'accountId' => 'account_id'
+        'flagColor' => 'flag_color',
+        'accountId' => 'account_id',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id'
     ];
 
     /**
@@ -125,7 +137,11 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'setDateNext',
         'frequency' => 'setFrequency',
         'amount' => 'setAmount',
-        'accountId' => 'setAccountId'
+        'flagColor' => 'setFlagColor',
+        'accountId' => 'setAccountId',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId'
     ];
 
     /**
@@ -139,7 +155,11 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         'dateNext' => 'getDateNext',
         'frequency' => 'getFrequency',
         'amount' => 'getAmount',
-        'accountId' => 'getAccountId'
+        'flagColor' => 'getFlagColor',
+        'accountId' => 'getAccountId',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId'
     ];
 
     /**
@@ -196,6 +216,12 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
     const FREQUENCY_TWICE_A_YEAR = 'twiceAYear';
     const FREQUENCY_YEARLY = 'yearly';
     const FREQUENCY_EVERY_OTHER_YEAR = 'everyOtherYear';
+    const FLAG_COLOR_RED = 'red';
+    const FLAG_COLOR_ORANGE = 'orange';
+    const FLAG_COLOR_YELLOW = 'yellow';
+    const FLAG_COLOR_GREEN = 'green';
+    const FLAG_COLOR_BLUE = 'blue';
+    const FLAG_COLOR_PURPLE = 'purple';
     
 
     
@@ -223,6 +249,23 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         ];
     }
     
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getFlagColorAllowableValues()
+    {
+        return [
+            self::FLAG_COLOR_RED,
+            self::FLAG_COLOR_ORANGE,
+            self::FLAG_COLOR_YELLOW,
+            self::FLAG_COLOR_GREEN,
+            self::FLAG_COLOR_BLUE,
+            self::FLAG_COLOR_PURPLE,
+        ];
+    }
+    
 
     /**
      * Associative array for storing property values
@@ -244,7 +287,11 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         $this->container['dateNext'] = isset($data['dateNext']) ? $data['dateNext'] : null;
         $this->container['frequency'] = isset($data['frequency']) ? $data['frequency'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
     }
 
     /**
@@ -279,8 +326,28 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
         }
+        if ($this->container['flagColor'] === null) {
+            $invalidProperties[] = "'flagColor' can't be null";
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'flagColor', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
         if ($this->container['accountId'] === null) {
             $invalidProperties[] = "'accountId' can't be null";
+        }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
         }
         return $invalidProperties;
     }
@@ -313,7 +380,23 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             return false;
         }
+        if ($this->container['flagColor'] === null) {
+            return false;
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            return false;
+        }
         if ($this->container['accountId'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
             return false;
         }
         return true;
@@ -450,6 +533,39 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets flagColor
+     *
+     * @return string
+     */
+    public function getFlagColor()
+    {
+        return $this->container['flagColor'];
+    }
+
+    /**
+     * Sets flagColor
+     *
+     * @param string $flagColor The scheduled transaction flag
+     *
+     * @return $this
+     */
+    public function setFlagColor($flagColor)
+    {
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($flagColor, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'flagColor', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['flagColor'] = $flagColor;
+
+        return $this;
+    }
+
+    /**
      * Gets accountId
      *
      * @return string
@@ -469,6 +585,78 @@ class ScheduledTransactionSummary implements ModelInterface, ArrayAccess
     public function setAccountId($accountId)
     {
         $this->container['accountId'] = $accountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId If a transfer, the account_id which the scheduled transaction transfers to
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
 
         return $this;
     }

--- a/src/Model/SubTransaction.php
+++ b/src/Model/SubTransaction.php
@@ -59,7 +59,10 @@ class SubTransaction implements ModelInterface, ArrayAccess
     protected static $swaggerTypes = [
         'id' => 'string',
         'transactionId' => 'string',
-        'amount' => 'float'
+        'amount' => 'float',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string'
     ];
 
     /**
@@ -70,7 +73,10 @@ class SubTransaction implements ModelInterface, ArrayAccess
     protected static $swaggerFormats = [
         'id' => 'uuid',
         'transactionId' => 'uuid',
-        'amount' => '1234000'
+        'amount' => '1234000',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid'
     ];
 
     /**
@@ -102,7 +108,10 @@ class SubTransaction implements ModelInterface, ArrayAccess
     protected static $attributeMap = [
         'id' => 'id',
         'transactionId' => 'transaction_id',
-        'amount' => 'amount'
+        'amount' => 'amount',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id'
     ];
 
     /**
@@ -113,7 +122,10 @@ class SubTransaction implements ModelInterface, ArrayAccess
     protected static $setters = [
         'id' => 'setId',
         'transactionId' => 'setTransactionId',
-        'amount' => 'setAmount'
+        'amount' => 'setAmount',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId'
     ];
 
     /**
@@ -124,7 +136,10 @@ class SubTransaction implements ModelInterface, ArrayAccess
     protected static $getters = [
         'id' => 'getId',
         'transactionId' => 'getTransactionId',
-        'amount' => 'getAmount'
+        'amount' => 'getAmount',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId'
     ];
 
     /**
@@ -190,6 +205,9 @@ class SubTransaction implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['transactionId'] = isset($data['transactionId']) ? $data['transactionId'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
     }
 
     /**
@@ -210,6 +228,15 @@ class SubTransaction implements ModelInterface, ArrayAccess
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
         }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
+        }
         return $invalidProperties;
     }
 
@@ -229,6 +256,15 @@ class SubTransaction implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
             return false;
         }
         return true;
@@ -303,6 +339,78 @@ class SubTransaction implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId If a transfer, the account_id which the subtransaction transfers to
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
 
         return $this;
     }

--- a/src/Model/SubTransaction.php
+++ b/src/Model/SubTransaction.php
@@ -60,6 +60,7 @@ class SubTransaction implements ModelInterface, ArrayAccess
         'id' => 'string',
         'transactionId' => 'string',
         'amount' => 'float',
+        'memo' => 'string',
         'payeeId' => 'string',
         'categoryId' => 'string',
         'transferAccountId' => 'string'
@@ -74,6 +75,7 @@ class SubTransaction implements ModelInterface, ArrayAccess
         'id' => 'uuid',
         'transactionId' => 'uuid',
         'amount' => '1234000',
+        'memo' => null,
         'payeeId' => 'uuid',
         'categoryId' => 'uuid',
         'transferAccountId' => 'uuid'
@@ -109,6 +111,7 @@ class SubTransaction implements ModelInterface, ArrayAccess
         'id' => 'id',
         'transactionId' => 'transaction_id',
         'amount' => 'amount',
+        'memo' => 'memo',
         'payeeId' => 'payee_id',
         'categoryId' => 'category_id',
         'transferAccountId' => 'transfer_account_id'
@@ -123,6 +126,7 @@ class SubTransaction implements ModelInterface, ArrayAccess
         'id' => 'setId',
         'transactionId' => 'setTransactionId',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'payeeId' => 'setPayeeId',
         'categoryId' => 'setCategoryId',
         'transferAccountId' => 'setTransferAccountId'
@@ -137,6 +141,7 @@ class SubTransaction implements ModelInterface, ArrayAccess
         'id' => 'getId',
         'transactionId' => 'getTransactionId',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'payeeId' => 'getPayeeId',
         'categoryId' => 'getCategoryId',
         'transferAccountId' => 'getTransferAccountId'
@@ -205,6 +210,7 @@ class SubTransaction implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['transactionId'] = isset($data['transactionId']) ? $data['transactionId'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
         $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
         $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
@@ -227,6 +233,9 @@ class SubTransaction implements ModelInterface, ArrayAccess
         }
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
+        }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
         }
         if ($this->container['payeeId'] === null) {
             $invalidProperties[] = "'payeeId' can't be null";
@@ -256,6 +265,9 @@ class SubTransaction implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['memo'] === null) {
             return false;
         }
         if ($this->container['payeeId'] === null) {
@@ -339,6 +351,30 @@ class SubTransaction implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }

--- a/src/Model/TransactionDetail.php
+++ b/src/Model/TransactionDetail.php
@@ -60,6 +60,7 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'id' => 'string',
         'date' => '\DateTime',
         'amount' => 'float',
+        'memo' => 'string',
         'cleared' => 'string',
         'approved' => 'bool',
         'flagColor' => 'string',
@@ -69,6 +70,8 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'transferAccountId' => 'string',
         'importId' => 'string',
         'accountName' => 'string',
+        'payeeName' => 'string',
+        'categoryName' => 'string',
         'subtransactions' => '\YNAB\Model\SubTransaction[]'
     ];
 
@@ -81,6 +84,7 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'id' => 'uuid',
         'date' => 'date',
         'amount' => '1234000',
+        'memo' => null,
         'cleared' => null,
         'approved' => null,
         'flagColor' => null,
@@ -90,6 +94,8 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'transferAccountId' => 'uuid',
         'importId' => null,
         'accountName' => null,
+        'payeeName' => null,
+        'categoryName' => null,
         'subtransactions' => null
     ];
 
@@ -123,6 +129,7 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'id' => 'id',
         'date' => 'date',
         'amount' => 'amount',
+        'memo' => 'memo',
         'cleared' => 'cleared',
         'approved' => 'approved',
         'flagColor' => 'flag_color',
@@ -132,6 +139,8 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'transferAccountId' => 'transfer_account_id',
         'importId' => 'import_id',
         'accountName' => 'account_name',
+        'payeeName' => 'payee_name',
+        'categoryName' => 'category_name',
         'subtransactions' => 'subtransactions'
     ];
 
@@ -144,6 +153,7 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'id' => 'setId',
         'date' => 'setDate',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
         'flagColor' => 'setFlagColor',
@@ -153,6 +163,8 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'transferAccountId' => 'setTransferAccountId',
         'importId' => 'setImportId',
         'accountName' => 'setAccountName',
+        'payeeName' => 'setPayeeName',
+        'categoryName' => 'setCategoryName',
         'subtransactions' => 'setSubtransactions'
     ];
 
@@ -165,6 +177,7 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'id' => 'getId',
         'date' => 'getDate',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
         'flagColor' => 'getFlagColor',
@@ -174,6 +187,8 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'transferAccountId' => 'getTransferAccountId',
         'importId' => 'getImportId',
         'accountName' => 'getAccountName',
+        'payeeName' => 'getPayeeName',
+        'categoryName' => 'getCategoryName',
         'subtransactions' => 'getSubtransactions'
     ];
 
@@ -280,6 +295,7 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
         $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
@@ -289,6 +305,8 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
         $this->container['importId'] = isset($data['importId']) ? $data['importId'] : null;
         $this->container['accountName'] = isset($data['accountName']) ? $data['accountName'] : null;
+        $this->container['payeeName'] = isset($data['payeeName']) ? $data['payeeName'] : null;
+        $this->container['categoryName'] = isset($data['categoryName']) ? $data['categoryName'] : null;
         $this->container['subtransactions'] = isset($data['subtransactions']) ? $data['subtransactions'] : null;
     }
 
@@ -309,6 +327,9 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         }
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
+        }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
         }
         if ($this->container['cleared'] === null) {
             $invalidProperties[] = "'cleared' can't be null";
@@ -353,6 +374,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['accountName'] === null) {
             $invalidProperties[] = "'accountName' can't be null";
         }
+        if ($this->container['payeeName'] === null) {
+            $invalidProperties[] = "'payeeName' can't be null";
+        }
+        if ($this->container['categoryName'] === null) {
+            $invalidProperties[] = "'categoryName' can't be null";
+        }
         if ($this->container['subtransactions'] === null) {
             $invalidProperties[] = "'subtransactions' can't be null";
         }
@@ -375,6 +402,9 @@ class TransactionDetail implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['memo'] === null) {
             return false;
         }
         if ($this->container['cleared'] === null) {
@@ -410,6 +440,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['accountName'] === null) {
+            return false;
+        }
+        if ($this->container['payeeName'] === null) {
+            return false;
+        }
+        if ($this->container['categoryName'] === null) {
             return false;
         }
         if ($this->container['subtransactions'] === null) {
@@ -487,6 +523,30 @@ class TransactionDetail implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }
@@ -721,6 +781,54 @@ class TransactionDetail implements ModelInterface, ArrayAccess
     public function setAccountName($accountName)
     {
         $this->container['accountName'] = $accountName;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeName
+     *
+     * @return string
+     */
+    public function getPayeeName()
+    {
+        return $this->container['payeeName'];
+    }
+
+    /**
+     * Sets payeeName
+     *
+     * @param string $payeeName payeeName
+     *
+     * @return $this
+     */
+    public function setPayeeName($payeeName)
+    {
+        $this->container['payeeName'] = $payeeName;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryName
+     *
+     * @return string
+     */
+    public function getCategoryName()
+    {
+        return $this->container['categoryName'];
+    }
+
+    /**
+     * Sets categoryName
+     *
+     * @param string $categoryName categoryName
+     *
+     * @return $this
+     */
+    public function setCategoryName($categoryName)
+    {
+        $this->container['categoryName'] = $categoryName;
 
         return $this;
     }

--- a/src/Model/TransactionDetail.php
+++ b/src/Model/TransactionDetail.php
@@ -62,7 +62,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'amount' => 'float',
         'cleared' => 'string',
         'approved' => 'bool',
+        'flagColor' => 'string',
         'accountId' => 'string',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string',
+        'importId' => 'string',
         'accountName' => 'string',
         'subtransactions' => '\YNAB\Model\SubTransaction[]'
     ];
@@ -78,7 +83,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'amount' => '1234000',
         'cleared' => null,
         'approved' => null,
+        'flagColor' => null,
         'accountId' => 'uuid',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid',
+        'importId' => null,
         'accountName' => null,
         'subtransactions' => null
     ];
@@ -115,7 +125,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'amount' => 'amount',
         'cleared' => 'cleared',
         'approved' => 'approved',
+        'flagColor' => 'flag_color',
         'accountId' => 'account_id',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id',
+        'importId' => 'import_id',
         'accountName' => 'account_name',
         'subtransactions' => 'subtransactions'
     ];
@@ -131,7 +146,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'amount' => 'setAmount',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
+        'flagColor' => 'setFlagColor',
         'accountId' => 'setAccountId',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId',
+        'importId' => 'setImportId',
         'accountName' => 'setAccountName',
         'subtransactions' => 'setSubtransactions'
     ];
@@ -147,7 +167,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         'amount' => 'getAmount',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
+        'flagColor' => 'getFlagColor',
         'accountId' => 'getAccountId',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId',
+        'importId' => 'getImportId',
         'accountName' => 'getAccountName',
         'subtransactions' => 'getSubtransactions'
     ];
@@ -196,6 +221,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
     const CLEARED_CLEARED = 'cleared';
     const CLEARED_UNCLEARED = 'uncleared';
     const CLEARED_RECONCILED = 'reconciled';
+    const FLAG_COLOR_RED = 'red';
+    const FLAG_COLOR_ORANGE = 'orange';
+    const FLAG_COLOR_YELLOW = 'yellow';
+    const FLAG_COLOR_GREEN = 'green';
+    const FLAG_COLOR_BLUE = 'blue';
+    const FLAG_COLOR_PURPLE = 'purple';
     
 
     
@@ -210,6 +241,23 @@ class TransactionDetail implements ModelInterface, ArrayAccess
             self::CLEARED_CLEARED,
             self::CLEARED_UNCLEARED,
             self::CLEARED_RECONCILED,
+        ];
+    }
+    
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getFlagColorAllowableValues()
+    {
+        return [
+            self::FLAG_COLOR_RED,
+            self::FLAG_COLOR_ORANGE,
+            self::FLAG_COLOR_YELLOW,
+            self::FLAG_COLOR_GREEN,
+            self::FLAG_COLOR_BLUE,
+            self::FLAG_COLOR_PURPLE,
         ];
     }
     
@@ -234,7 +282,12 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
+        $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
+        $this->container['importId'] = isset($data['importId']) ? $data['importId'] : null;
         $this->container['accountName'] = isset($data['accountName']) ? $data['accountName'] : null;
         $this->container['subtransactions'] = isset($data['subtransactions']) ? $data['subtransactions'] : null;
     }
@@ -271,8 +324,31 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['approved'] === null) {
             $invalidProperties[] = "'approved' can't be null";
         }
+        if ($this->container['flagColor'] === null) {
+            $invalidProperties[] = "'flagColor' can't be null";
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'flagColor', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
         if ($this->container['accountId'] === null) {
             $invalidProperties[] = "'accountId' can't be null";
+        }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
+        }
+        if ($this->container['importId'] === null) {
+            $invalidProperties[] = "'importId' can't be null";
         }
         if ($this->container['accountName'] === null) {
             $invalidProperties[] = "'accountName' can't be null";
@@ -311,7 +387,26 @@ class TransactionDetail implements ModelInterface, ArrayAccess
         if ($this->container['approved'] === null) {
             return false;
         }
+        if ($this->container['flagColor'] === null) {
+            return false;
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            return false;
+        }
         if ($this->container['accountId'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
+            return false;
+        }
+        if ($this->container['importId'] === null) {
             return false;
         }
         if ($this->container['accountName'] === null) {
@@ -454,6 +549,39 @@ class TransactionDetail implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets flagColor
+     *
+     * @return string
+     */
+    public function getFlagColor()
+    {
+        return $this->container['flagColor'];
+    }
+
+    /**
+     * Sets flagColor
+     *
+     * @param string $flagColor The transaction flag
+     *
+     * @return $this
+     */
+    public function setFlagColor($flagColor)
+    {
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($flagColor, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'flagColor', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['flagColor'] = $flagColor;
+
+        return $this;
+    }
+
+    /**
      * Gets accountId
      *
      * @return string
@@ -473,6 +601,102 @@ class TransactionDetail implements ModelInterface, ArrayAccess
     public function setAccountId($accountId)
     {
         $this->container['accountId'] = $accountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId transferAccountId
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets importId
+     *
+     * @return string
+     */
+    public function getImportId()
+    {
+        return $this->container['importId'];
+    }
+
+    /**
+     * Sets importId
+     *
+     * @param string $importId If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     *
+     * @return $this
+     */
+    public function setImportId($importId)
+    {
+        $this->container['importId'] = $importId;
 
         return $this;
     }

--- a/src/Model/TransactionSummary.php
+++ b/src/Model/TransactionSummary.php
@@ -60,6 +60,7 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'id' => 'string',
         'date' => '\DateTime',
         'amount' => 'float',
+        'memo' => 'string',
         'cleared' => 'string',
         'approved' => 'bool',
         'flagColor' => 'string',
@@ -79,6 +80,7 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'id' => 'uuid',
         'date' => 'date',
         'amount' => '1234000',
+        'memo' => null,
         'cleared' => null,
         'approved' => null,
         'flagColor' => null,
@@ -119,6 +121,7 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'id' => 'id',
         'date' => 'date',
         'amount' => 'amount',
+        'memo' => 'memo',
         'cleared' => 'cleared',
         'approved' => 'approved',
         'flagColor' => 'flag_color',
@@ -138,6 +141,7 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'id' => 'setId',
         'date' => 'setDate',
         'amount' => 'setAmount',
+        'memo' => 'setMemo',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
         'flagColor' => 'setFlagColor',
@@ -157,6 +161,7 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'id' => 'getId',
         'date' => 'getDate',
         'amount' => 'getAmount',
+        'memo' => 'getMemo',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
         'flagColor' => 'getFlagColor',
@@ -270,6 +275,7 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
+        $this->container['memo'] = isset($data['memo']) ? $data['memo'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
         $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
@@ -297,6 +303,9 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         }
         if ($this->container['amount'] === null) {
             $invalidProperties[] = "'amount' can't be null";
+        }
+        if ($this->container['memo'] === null) {
+            $invalidProperties[] = "'memo' can't be null";
         }
         if ($this->container['cleared'] === null) {
             $invalidProperties[] = "'cleared' can't be null";
@@ -357,6 +366,9 @@ class TransactionSummary implements ModelInterface, ArrayAccess
             return false;
         }
         if ($this->container['amount'] === null) {
+            return false;
+        }
+        if ($this->container['memo'] === null) {
             return false;
         }
         if ($this->container['cleared'] === null) {
@@ -463,6 +475,30 @@ class TransactionSummary implements ModelInterface, ArrayAccess
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Gets memo
+     *
+     * @return string
+     */
+    public function getMemo()
+    {
+        return $this->container['memo'];
+    }
+
+    /**
+     * Sets memo
+     *
+     * @param string $memo memo
+     *
+     * @return $this
+     */
+    public function setMemo($memo)
+    {
+        $this->container['memo'] = $memo;
 
         return $this;
     }

--- a/src/Model/TransactionSummary.php
+++ b/src/Model/TransactionSummary.php
@@ -62,7 +62,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'amount' => 'float',
         'cleared' => 'string',
         'approved' => 'bool',
-        'accountId' => 'string'
+        'flagColor' => 'string',
+        'accountId' => 'string',
+        'payeeId' => 'string',
+        'categoryId' => 'string',
+        'transferAccountId' => 'string',
+        'importId' => 'string'
     ];
 
     /**
@@ -76,7 +81,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'amount' => '1234000',
         'cleared' => null,
         'approved' => null,
-        'accountId' => 'uuid'
+        'flagColor' => null,
+        'accountId' => 'uuid',
+        'payeeId' => 'uuid',
+        'categoryId' => 'uuid',
+        'transferAccountId' => 'uuid',
+        'importId' => null
     ];
 
     /**
@@ -111,7 +121,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'amount' => 'amount',
         'cleared' => 'cleared',
         'approved' => 'approved',
-        'accountId' => 'account_id'
+        'flagColor' => 'flag_color',
+        'accountId' => 'account_id',
+        'payeeId' => 'payee_id',
+        'categoryId' => 'category_id',
+        'transferAccountId' => 'transfer_account_id',
+        'importId' => 'import_id'
     ];
 
     /**
@@ -125,7 +140,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'amount' => 'setAmount',
         'cleared' => 'setCleared',
         'approved' => 'setApproved',
-        'accountId' => 'setAccountId'
+        'flagColor' => 'setFlagColor',
+        'accountId' => 'setAccountId',
+        'payeeId' => 'setPayeeId',
+        'categoryId' => 'setCategoryId',
+        'transferAccountId' => 'setTransferAccountId',
+        'importId' => 'setImportId'
     ];
 
     /**
@@ -139,7 +159,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         'amount' => 'getAmount',
         'cleared' => 'getCleared',
         'approved' => 'getApproved',
-        'accountId' => 'getAccountId'
+        'flagColor' => 'getFlagColor',
+        'accountId' => 'getAccountId',
+        'payeeId' => 'getPayeeId',
+        'categoryId' => 'getCategoryId',
+        'transferAccountId' => 'getTransferAccountId',
+        'importId' => 'getImportId'
     ];
 
     /**
@@ -186,6 +211,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
     const CLEARED_CLEARED = 'cleared';
     const CLEARED_UNCLEARED = 'uncleared';
     const CLEARED_RECONCILED = 'reconciled';
+    const FLAG_COLOR_RED = 'red';
+    const FLAG_COLOR_ORANGE = 'orange';
+    const FLAG_COLOR_YELLOW = 'yellow';
+    const FLAG_COLOR_GREEN = 'green';
+    const FLAG_COLOR_BLUE = 'blue';
+    const FLAG_COLOR_PURPLE = 'purple';
     
 
     
@@ -200,6 +231,23 @@ class TransactionSummary implements ModelInterface, ArrayAccess
             self::CLEARED_CLEARED,
             self::CLEARED_UNCLEARED,
             self::CLEARED_RECONCILED,
+        ];
+    }
+    
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getFlagColorAllowableValues()
+    {
+        return [
+            self::FLAG_COLOR_RED,
+            self::FLAG_COLOR_ORANGE,
+            self::FLAG_COLOR_YELLOW,
+            self::FLAG_COLOR_GREEN,
+            self::FLAG_COLOR_BLUE,
+            self::FLAG_COLOR_PURPLE,
         ];
     }
     
@@ -224,7 +272,12 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['cleared'] = isset($data['cleared']) ? $data['cleared'] : null;
         $this->container['approved'] = isset($data['approved']) ? $data['approved'] : null;
+        $this->container['flagColor'] = isset($data['flagColor']) ? $data['flagColor'] : null;
         $this->container['accountId'] = isset($data['accountId']) ? $data['accountId'] : null;
+        $this->container['payeeId'] = isset($data['payeeId']) ? $data['payeeId'] : null;
+        $this->container['categoryId'] = isset($data['categoryId']) ? $data['categoryId'] : null;
+        $this->container['transferAccountId'] = isset($data['transferAccountId']) ? $data['transferAccountId'] : null;
+        $this->container['importId'] = isset($data['importId']) ? $data['importId'] : null;
     }
 
     /**
@@ -259,8 +312,31 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         if ($this->container['approved'] === null) {
             $invalidProperties[] = "'approved' can't be null";
         }
+        if ($this->container['flagColor'] === null) {
+            $invalidProperties[] = "'flagColor' can't be null";
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'flagColor', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
         if ($this->container['accountId'] === null) {
             $invalidProperties[] = "'accountId' can't be null";
+        }
+        if ($this->container['payeeId'] === null) {
+            $invalidProperties[] = "'payeeId' can't be null";
+        }
+        if ($this->container['categoryId'] === null) {
+            $invalidProperties[] = "'categoryId' can't be null";
+        }
+        if ($this->container['transferAccountId'] === null) {
+            $invalidProperties[] = "'transferAccountId' can't be null";
+        }
+        if ($this->container['importId'] === null) {
+            $invalidProperties[] = "'importId' can't be null";
         }
         return $invalidProperties;
     }
@@ -293,7 +369,26 @@ class TransactionSummary implements ModelInterface, ArrayAccess
         if ($this->container['approved'] === null) {
             return false;
         }
+        if ($this->container['flagColor'] === null) {
+            return false;
+        }
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($this->container['flagColor'], $allowedValues)) {
+            return false;
+        }
         if ($this->container['accountId'] === null) {
+            return false;
+        }
+        if ($this->container['payeeId'] === null) {
+            return false;
+        }
+        if ($this->container['categoryId'] === null) {
+            return false;
+        }
+        if ($this->container['transferAccountId'] === null) {
+            return false;
+        }
+        if ($this->container['importId'] === null) {
             return false;
         }
         return true;
@@ -430,6 +525,39 @@ class TransactionSummary implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets flagColor
+     *
+     * @return string
+     */
+    public function getFlagColor()
+    {
+        return $this->container['flagColor'];
+    }
+
+    /**
+     * Sets flagColor
+     *
+     * @param string $flagColor The transaction flag
+     *
+     * @return $this
+     */
+    public function setFlagColor($flagColor)
+    {
+        $allowedValues = $this->getFlagColorAllowableValues();
+        if (!in_array($flagColor, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'flagColor', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['flagColor'] = $flagColor;
+
+        return $this;
+    }
+
+    /**
      * Gets accountId
      *
      * @return string
@@ -449,6 +577,102 @@ class TransactionSummary implements ModelInterface, ArrayAccess
     public function setAccountId($accountId)
     {
         $this->container['accountId'] = $accountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets payeeId
+     *
+     * @return string
+     */
+    public function getPayeeId()
+    {
+        return $this->container['payeeId'];
+    }
+
+    /**
+     * Sets payeeId
+     *
+     * @param string $payeeId payeeId
+     *
+     * @return $this
+     */
+    public function setPayeeId($payeeId)
+    {
+        $this->container['payeeId'] = $payeeId;
+
+        return $this;
+    }
+
+    /**
+     * Gets categoryId
+     *
+     * @return string
+     */
+    public function getCategoryId()
+    {
+        return $this->container['categoryId'];
+    }
+
+    /**
+     * Sets categoryId
+     *
+     * @param string $categoryId categoryId
+     *
+     * @return $this
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->container['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * Gets transferAccountId
+     *
+     * @return string
+     */
+    public function getTransferAccountId()
+    {
+        return $this->container['transferAccountId'];
+    }
+
+    /**
+     * Sets transferAccountId
+     *
+     * @param string $transferAccountId transferAccountId
+     *
+     * @return $this
+     */
+    public function setTransferAccountId($transferAccountId)
+    {
+        $this->container['transferAccountId'] = $transferAccountId;
+
+        return $this;
+    }
+
+    /**
+     * Gets importId
+     *
+     * @return string
+     */
+    public function getImportId()
+    {
+        return $this->container['importId'];
+    }
+
+    /**
+     * Sets importId
+     *
+     * @param string $importId If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.
+     *
+     * @return $this
+     */
+    public function setImportId($importId)
+    {
+        $this->container['importId'] = $importId;
 
         return $this;
     }

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,2656 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Our API uses a REST based design, leverages the JSON data format, and relies upon HTTPS for transport. We respond with meaningful HTTP response codes and if an error occurs, we include error details in the response body.  API Documentation is at https://api.youneedabudget.com",
+        "version": "1.0.0",
+        "title": "YNAB API Endpoints"
+    },
+    "schemes": [
+        "https"
+    ],
+    "host": "api.youneedabudget.com",
+    "basePath": "/v1",
+    "tags": [
+        {
+            "name": "User"
+        },
+        {
+            "name": "Budgets"
+        },
+        {
+            "name": "Accounts",
+            "description": "The Accounts for a budget."
+        },
+        {
+            "name": "Categories",
+            "description": "The Categories for a budget."
+        },
+        {
+            "name": "Payees",
+            "description": "The Payees for a budget."
+        },
+        {
+            "name": "Payee Locations",
+            "description": "When you enter a transaction and specify a payee on the YNAB mobile apps, the GPS coordinates for that location are stored, with your permission, so that the next time you are in the same place (like the Grocery store) we can pre-populate nearby payees for you!  Itâ€™s handy and saves you time.  This resource makes these locations available.  Locations will not be available for all payees."
+        },
+        {
+            "name": "Months",
+            "description": "Each budget contains one or more months, which is where To be Budgeted, Age of Money and Category (budgeted / activity / balances) amounts are available."
+        },
+        {
+            "name": "Transactions",
+            "description": "The Transactions for a budget."
+        },
+        {
+            "name": "Scheduled Transactions",
+            "description": "The Scheduled Transactions for a budget."
+        }
+    ],
+    "security": [
+        {
+            "bearer": []
+        }
+    ],
+    "paths": {
+        "/user": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "User info",
+                "description": "Returns authenticated user information.",
+                "operationId": "getUser",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The user info.",
+                        "schema": {
+                            "$ref": "#/definitions/UserResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets": {
+            "get": {
+                "tags": [
+                    "Budgets"
+                ],
+                "summary": "List budgets",
+                "description": "Returns budgets list with summary information.",
+                "operationId": "getBudgets",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "The list of budgets.",
+                        "schema": {
+                            "$ref": "#/definitions/BudgetSummaryResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No budgets were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}": {
+            "get": {
+                "tags": [
+                    "Budgets"
+                ],
+                "summary": "Single budget",
+                "description": "Returns a single budget with all related entities.  This resource is effectively a full budget export.",
+                "operationId": "getBudgetById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "last_knowledge_of_server",
+                        "in": "query",
+                        "description": "The starting server knowledge.  If provided, only entities that have changed since last_knowledge_of_server will be included.",
+                        "required": false,
+                        "type": "number"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested Budget.",
+                        "schema": {
+                            "$ref": "#/definitions/BudgetDetailResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The specified Budget was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/accounts": {
+            "get": {
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "Account list",
+                "description": "Returns all accounts",
+                "operationId": "getAccounts",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Accounts.",
+                        "schema": {
+                            "$ref": "#/definitions/AccountsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Accounts were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/accounts/{account_id}": {
+            "get": {
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "Single account",
+                "description": "Returns a single account",
+                "operationId": "getAccountById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "account_id",
+                        "in": "path",
+                        "description": "The ID of the Account.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested Account.",
+                        "schema": {
+                            "$ref": "#/definitions/AccountResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The requested Account was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/categories": {
+            "get": {
+                "tags": [
+                    "Categories"
+                ],
+                "summary": "List categories",
+                "description": "Returns all categories grouped by category group.",
+                "operationId": "getCategories",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Categories grouped by Category Group.",
+                        "schema": {
+                            "$ref": "#/definitions/CategoriesResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No categories were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/categories/{category_id}": {
+            "get": {
+                "tags": [
+                    "Categories"
+                ],
+                "summary": "Single category",
+                "description": "Returns a single category",
+                "operationId": "getCategoryById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "category_id",
+                        "in": "path",
+                        "description": "The ID of the Category.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested Category.",
+                        "schema": {
+                            "$ref": "#/definitions/CategoryResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The Category not was found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/payees": {
+            "get": {
+                "tags": [
+                    "Payees"
+                ],
+                "summary": "List payees",
+                "description": "Returns all payees",
+                "operationId": "getPayees",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested list of Payees.",
+                        "schema": {
+                            "$ref": "#/definitions/PayeesResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Payees were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/payees/{payee_id}": {
+            "get": {
+                "tags": [
+                    "Payees"
+                ],
+                "summary": "Single payee",
+                "description": "Returns single payee",
+                "operationId": "getPayeeById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "payee_id",
+                        "in": "path",
+                        "description": "The ID of the Payee.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested Payee.",
+                        "schema": {
+                            "$ref": "#/definitions/PayeeResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The Payee was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/payee_locations": {
+            "get": {
+                "tags": [
+                    "Payee Locations"
+                ],
+                "summary": "List payee locations",
+                "description": "Returns all payee locations",
+                "operationId": "getPayeeLocations",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of Payee Locations.",
+                        "schema": {
+                            "$ref": "#/definitions/PayeeLocationsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Payees Locations were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/payee_locations/{payee_location_id}": {
+            "get": {
+                "tags": [
+                    "Payee Locations"
+                ],
+                "summary": "Single payee location",
+                "description": "Returns a single payee location",
+                "operationId": "getPayeeLocationById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "payee_location_id",
+                        "in": "path",
+                        "description": "ID of payee location",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Payee Location",
+                        "schema": {
+                            "$ref": "#/definitions/PayeeLocationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Payee location not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/payees/{payee_id}/payee_locations": {
+            "get": {
+                "tags": [
+                    "Payee Locations"
+                ],
+                "summary": "List locations for a payee",
+                "description": "Returns all payee locations for the specified payee",
+                "operationId": "getPayeeLocationsByPayee",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "payee_id",
+                        "in": "path",
+                        "description": "ID of payee",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Payee Locations.",
+                        "schema": {
+                            "$ref": "#/definitions/PayeeLocationsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Payees Locations were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/months": {
+            "get": {
+                "tags": [
+                    "Months"
+                ],
+                "summary": "List budget months",
+                "description": "Returns all budget months",
+                "operationId": "getBudgetMonths",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of Budget Months.",
+                        "schema": {
+                            "$ref": "#/definitions/MonthSummariesResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Budget Months were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/months/{month}": {
+            "get": {
+                "tags": [
+                    "Months"
+                ],
+                "summary": "Single budget month",
+                "description": "Returns a single budget month",
+                "operationId": "getBudgetMonth",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "month",
+                        "in": "path",
+                        "description": "The Budget Month.  \"current\" can also be used to specify the current calendar month (UTC).",
+                        "required": true,
+                        "type": "string",
+                        "format": "date"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Budget Month detail.",
+                        "schema": {
+                            "$ref": "#/definitions/MonthDetailResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The Budget Month was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/transactions": {
+            "get": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "List transactions",
+                "description": "Returns budget transactions",
+                "operationId": "getTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "since_date",
+                        "in": "query",
+                        "description": "Only return transactions on or after this date.",
+                        "required": false,
+                        "type": "string",
+                        "format": "date"
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Only return transactions of a certain type (i.e. 'uncategorized', 'unapproved')",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "uncategorized",
+                            "unapproved"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Transactions.",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Transactions were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Create new transaction",
+                "description": "Creates a transaction",
+                "operationId": "createTransaction",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "transaction",
+                        "in": "body",
+                        "description": "The Transaction to create.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/SaveTransactionWrapper"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "The Transaction was successfully created.",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "A transation with the same import_id already exists on the account so this transaction was not created.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/transactions/bulk": {
+            "post": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Bulk create transactions",
+                "description": "Creates multiple transactions",
+                "operationId": "bulkCreateTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "transactions",
+                        "in": "body",
+                        "description": "The list of Transactions to create.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/BulkTransactions"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "The bulk request was processed sucessfully.",
+                        "schema": {
+                            "$ref": "#/definitions/BulkResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/accounts/{account_id}/transactions": {
+            "get": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "List account transactions",
+                "description": "Returns all transactions for a specified account",
+                "operationId": "getTransactionsByAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "account_id",
+                        "in": "path",
+                        "description": "The ID of the Account.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "since_date",
+                        "in": "query",
+                        "description": "Only return transactions on or after this date.",
+                        "required": false,
+                        "type": "string",
+                        "format": "date"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Transactions.",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Transactions were found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/categories/{category_id}/transactions": {
+            "get": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "List category transactions",
+                "description": "Returns all transactions for a specified category",
+                "operationId": "getTransactionsByCategory",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "category_id",
+                        "in": "path",
+                        "description": "The ID of the Category.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "since_date",
+                        "in": "query",
+                        "description": "Only return transactions on or after this date.",
+                        "required": false,
+                        "type": "string",
+                        "format": "date"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Transactions.",
+                        "schema": {
+                            "$ref": "#/definitions/HybridTransactionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Transactions were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/payees/{payee_id}/transactions": {
+            "get": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "List payee transactions",
+                "description": "Returns all transactions for a specified payee",
+                "operationId": "getTransactionsByPayee",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "payee_id",
+                        "in": "path",
+                        "description": "The ID of the Payee.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "since_date",
+                        "in": "query",
+                        "description": "Only return transactions on or after this date.",
+                        "required": false,
+                        "type": "string",
+                        "format": "date"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Transactions.",
+                        "schema": {
+                            "$ref": "#/definitions/HybridTransactionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Transactions were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/transactions/{transaction_id}": {
+            "get": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Single transaction",
+                "description": "Returns a single transaction",
+                "operationId": "getTransactionsById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "transaction_id",
+                        "in": "path",
+                        "description": "The ID of the Transaction.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested Transaction.",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The Transaction was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Transactions"
+                ],
+                "summary": "Updates an existing transaction",
+                "description": "Updates a transaction",
+                "operationId": "updateTransaction",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "transaction_id",
+                        "in": "path",
+                        "description": "The ID of the Transaction.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "transaction",
+                        "in": "body",
+                        "description": "The Transaction to update.",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/SaveTransactionWrapper"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The Transaction was successfull updated.",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/scheduled_transactions": {
+            "get": {
+                "tags": [
+                    "Scheduled Transactions"
+                ],
+                "summary": "List scheduled transactions",
+                "description": "Returns all scheduled transactions",
+                "operationId": "getScheduledTransactions",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The list of requested Scheduled Transactions.",
+                        "schema": {
+                            "$ref": "#/definitions/ScheduledTransactionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No Scheduled Transactions were found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/budgets/{budget_id}/scheduled_transactions/{scheduled_transaction_id}": {
+            "get": {
+                "tags": [
+                    "Scheduled Transactions"
+                ],
+                "summary": "Single scheduled transaction",
+                "description": "Returns a single scheduled transaction",
+                "operationId": "getScheduledTransactionById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "budget_id",
+                        "in": "path",
+                        "description": "The ID of the Budget.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    {
+                        "name": "scheduled_transaction_id",
+                        "in": "path",
+                        "description": "The ID of the Scheduled Transaction.",
+                        "required": true,
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The requested Scheduled Transaction.",
+                        "schema": {
+                            "$ref": "#/definitions/ScheduledTransactionResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "The Scheduled Transaction was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "An error occurred.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "bearer": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
+    },
+    "definitions": {
+        "ErrorResponse": {
+            "type": "object",
+            "required": [
+                "error"
+            ],
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/ErrorDetail"
+                }
+            }
+        },
+        "ErrorDetail": {
+            "type": "object",
+            "required": [
+                "id",
+                "name",
+                "detail"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                }
+            }
+        },
+        "UserResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/UserWrapper"
+                }
+            }
+        },
+        "UserWrapper": {
+            "type": "object",
+            "required": [
+                "user"
+            ],
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/User"
+                }
+            }
+        },
+        "User": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            }
+        },
+        "BudgetSummaryResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/BudgetSummaryWrapper"
+                }
+            }
+        },
+        "BudgetSummaryWrapper": {
+            "type": "object",
+            "required": [
+                "budgets"
+            ],
+            "properties": {
+                "budgets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BudgetSummary"
+                    }
+                }
+            }
+        },
+        "BudgetDetailResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/BudgetDetailWrapper"
+                }
+            }
+        },
+        "BudgetDetailWrapper": {
+            "type": "object",
+            "required": [
+                "budget",
+                "server_knowledge"
+            ],
+            "properties": {
+                "budget": {
+                    "$ref": "#/definitions/BudgetDetail"
+                },
+                "server_knowledge": {
+                    "type": "number",
+                    "description": "The knowledge of the server"
+                }
+            }
+        },
+        "BudgetSummary": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "last_modified_on": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The last time any changes were made to the budget from either a web or mobile client."
+                },
+                "date_format": {
+                    "$ref": "#/definitions/DateFormat"
+                },
+                "currency_format": {
+                    "$ref": "#/definitions/CurrencyFormat"
+                }
+            }
+        },
+        "DateFormat": {
+            "type": "object",
+            "required": [
+                "format"
+            ],
+            "properties": {
+                "format": {
+                    "type": "string"
+                }
+            }
+        },
+        "CurrencyFormat": {
+            "type": "object",
+            "required": [
+                "iso_code",
+                "example_format",
+                "decimal_digits",
+                "decimal_separator",
+                "symbol_first",
+                "group_separator",
+                "currency_symbol",
+                "display_symbol"
+            ],
+            "properties": {
+                "iso_code": {
+                    "type": "string"
+                },
+                "example_format": {
+                    "type": "string"
+                },
+                "decimal_digits": {
+                    "type": "number"
+                },
+                "decimal_separator": {
+                    "type": "string"
+                },
+                "symbol_first": {
+                    "type": "boolean"
+                },
+                "group_separator": {
+                    "type": "string"
+                },
+                "currency_symbol": {
+                    "type": "string"
+                },
+                "display_symbol": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "BudgetDetail": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/BudgetSummary"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "accounts": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Account"
+                            }
+                        },
+                        "payees": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Payee"
+                            }
+                        },
+                        "payee_locations": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PayeeLocation"
+                            }
+                        },
+                        "category_groups": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CategoryGroup"
+                            }
+                        },
+                        "categories": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Category"
+                            }
+                        },
+                        "months": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MonthDetail"
+                            }
+                        },
+                        "transactions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TransactionSummary"
+                            }
+                        },
+                        "subtransactions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SubTransaction"
+                            }
+                        },
+                        "scheduled_transactions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ScheduledTransactionSummary"
+                            }
+                        },
+                        "scheduled_subtransactions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ScheduledSubTransaction"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "AccountsResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/AccountsWrapper"
+                }
+            }
+        },
+        "AccountsWrapper": {
+            "type": "object",
+            "required": [
+                "accounts"
+            ],
+            "properties": {
+                "accounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Account"
+                    }
+                }
+            }
+        },
+        "AccountResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/AccountWrapper"
+                }
+            }
+        },
+        "AccountWrapper": {
+            "type": "object",
+            "required": [
+                "account"
+            ],
+            "properties": {
+                "account": {
+                    "$ref": "#/definitions/Account"
+                }
+            }
+        },
+        "Account": {
+            "type": "object",
+            "required": [
+                "id",
+                "name",
+                "type",
+                "on_budget",
+                "closed",
+                "note",
+                "balance",
+                "cleared_balance",
+                "uncleared_balance"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "checking",
+                        "savings",
+                        "creditCard",
+                        "cash",
+                        "lineOfCredit",
+                        "merchantAccount",
+                        "payPal",
+                        "investmentAccount",
+                        "mortgage",
+                        "otherAsset",
+                        "otherLiability"
+                    ]
+                },
+                "on_budget": {
+                    "type": "boolean",
+                    "description": "Whether this account is on budget or not"
+                },
+                "closed": {
+                    "type": "boolean",
+                    "description": "Whether this account is closed or not"
+                },
+                "note": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "balance": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The current balance of the account in milliunits format"
+                },
+                "cleared_balance": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The current cleared balance of the account in milliunits format"
+                },
+                "uncleared_balance": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The current uncleared balance of the account in milliunits format"
+                }
+            }
+        },
+        "CategoriesResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/CategoryGroupsWrapper"
+                }
+            }
+        },
+        "CategoryGroupsWrapper": {
+            "type": "object",
+            "required": [
+                "category_groups"
+            ],
+            "properties": {
+                "category_groups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CategoryGroupWithCategories"
+                    }
+                }
+            }
+        },
+        "CategoryResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/CategoryWrapper"
+                }
+            }
+        },
+        "CategoryWrapper": {
+            "type": "object",
+            "required": [
+                "category"
+            ],
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/Category"
+                }
+            }
+        },
+        "CategoryGroup": {
+            "type": "object",
+            "required": [
+                "id",
+                "name",
+                "hidden"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "hidden": {
+                    "description": "Whether or not the category group is hidden",
+                    "type": "boolean"
+                }
+            }
+        },
+        "CategoryGroupWithCategories": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/CategoryGroup"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "categories"
+                    ],
+                    "properties": {
+                        "categories": {
+                            "type": "array",
+                            "description": "Category group categories",
+                            "items": {
+                                "$ref": "#/definitions/Category"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "Category": {
+            "type": "object",
+            "required": [
+                "id",
+                "category_group_id",
+                "name",
+                "hidden",
+                "note",
+                "activity",
+                "balance",
+                "budgeted"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "category_group_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "hidden": {
+                    "description": "Whether or not the category is hidden",
+                    "type": "boolean"
+                },
+                "note": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "budgeted": {
+                    "type": "number",
+                    "description": "Budgeted amount in current month in milliunits format"
+                },
+                "activity": {
+                    "type": "number",
+                    "description": "Activity amount in current month in milliunits format"
+                },
+                "balance": {
+                    "type": "number",
+                    "description": "Balance in current month in milliunits format"
+                }
+            }
+        },
+        "PayeesResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/PayeesWrapper"
+                }
+            }
+        },
+        "PayeesWrapper": {
+            "type": "object",
+            "required": [
+                "payees"
+            ],
+            "properties": {
+                "payees": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Payee"
+                    }
+                }
+            }
+        },
+        "PayeeResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/PayeeWrapper"
+                }
+            }
+        },
+        "PayeeWrapper": {
+            "type": "object",
+            "required": [
+                "payee"
+            ],
+            "properties": {
+                "payee": {
+                    "$ref": "#/definitions/Payee"
+                }
+            }
+        },
+        "Payee": {
+            "type": "object",
+            "required": [
+                "id",
+                "name",
+                "transfer_account_id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "transfer_account_id": {
+                    "description": "If a transfer payee, the account_id to which this payee transfers to",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "PayeeLocationsResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/PayeeLocationsWrapper"
+                }
+            }
+        },
+        "PayeeLocationsWrapper": {
+            "type": "object",
+            "required": [
+                "payee_locations"
+            ],
+            "properties": {
+                "payee_locations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PayeeLocation"
+                    }
+                }
+            }
+        },
+        "PayeeLocationResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/PayeeLocationWrapper"
+                }
+            }
+        },
+        "PayeeLocationWrapper": {
+            "type": "object",
+            "required": [
+                "payee_location"
+            ],
+            "properties": {
+                "payee_location": {
+                    "$ref": "#/definitions/PayeeLocation"
+                }
+            }
+        },
+        "PayeeLocation": {
+            "type": "object",
+            "required": [
+                "id",
+                "payee_id",
+                "latitude",
+                "longitude"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "payee_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "latitude": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "longitude": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "TransactionsResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/TransactionsWrapper"
+                }
+            }
+        },
+        "TransactionsWrapper": {
+            "type": "object",
+            "required": [
+                "transactions"
+            ],
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TransactionDetail"
+                    }
+                }
+            }
+        },
+        "HybridTransactionsResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/HybridTransactionsWrapper"
+                }
+            }
+        },
+        "HybridTransactionsWrapper": {
+            "type": "object",
+            "required": [
+                "transactions"
+            ],
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/HybridTransaction"
+                    }
+                }
+            }
+        },
+        "TransactionResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/TransactionWrapper"
+                }
+            }
+        },
+        "TransactionWrapper": {
+            "type": "object",
+            "required": [
+                "transaction"
+            ],
+            "properties": {
+                "transaction": {
+                    "$ref": "#/definitions/TransactionDetail"
+                }
+            }
+        },
+        "TransactionSummary": {
+            "type": "object",
+            "required": [
+                "id",
+                "date",
+                "amount",
+                "memo",
+                "cleared",
+                "approved",
+                "flag_color",
+                "account_id",
+                "payee_id",
+                "category_id",
+                "transfer_account_id",
+                "import_id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "amount": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The transaction amount in milliunits format"
+                },
+                "memo": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cleared": {
+                    "type": "string",
+                    "enum": [
+                        "cleared",
+                        "uncleared",
+                        "reconciled"
+                    ],
+                    "description": "The cleared status of the transaction"
+                },
+                "approved": {
+                    "type": "boolean",
+                    "description": "Whether or not the transaction is approved"
+                },
+                "flag_color": {
+                    "type": "string",
+                    "enum": [
+                        "red",
+                        "orange",
+                        "yellow",
+                        "green",
+                        "blue",
+                        "purple",
+                        null
+                    ],
+                    "description": "The transaction flag"
+                },
+                "account_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "payee_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "category_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "transfer_account_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "import_id": {
+                    "type": "string",
+                    "description": "If the Transaction was imported, this field is a unique (by account) import identifier.  If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'."
+                }
+            }
+        },
+        "TransactionDetail": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TransactionSummary"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "account_name",
+                        "payee_name",
+                        "category_name",
+                        "subtransactions"
+                    ],
+                    "properties": {
+                        "account_name": {
+                            "type": "string"
+                        },
+                        "payee_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "category_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "subtransactions": {
+                            "type": "array",
+                            "description": "If a split transaction, the subtransactions.",
+                            "items": {
+                                "$ref": "#/definitions/SubTransaction"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "HybridTransaction": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TransactionSummary"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "type",
+                        "parent_transaction_id",
+                        "account_name",
+                        "payee_name",
+                        "category_name"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "transaction",
+                                "subtransaction"
+                            ],
+                            "description": "Whether the hybrid transaction represents a regular transaction or a subtransaction"
+                        },
+                        "parent_transaction_id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "For subtransaction types, this is the id of the pararent transaction.  For transaction types, this id will be always be null."
+                        },
+                        "account_name": {
+                            "type": "string"
+                        },
+                        "payee_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "category_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "SaveTransactionWrapper": {
+            "type": "object",
+            "required": [
+                "transaction"
+            ],
+            "properties": {
+                "transaction": {
+                    "$ref": "#/definitions/SaveTransaction"
+                }
+            }
+        },
+        "SaveTransaction": {
+            "type": "object",
+            "required": [
+                "account_id",
+                "date",
+                "amount"
+            ],
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "amount": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The transaction amount in milliunits format"
+                },
+                "payee_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The payee for the transaction.  Transfer payees are not permitted and will be ignored if supplied."
+                },
+                "payee_name": {
+                    "type": "string",
+                    "description": "The payee name.  If a payee_name value is provided and payee_id is not included or has a null value, payee_name will be used to create or use an existing payee."
+                },
+                "category_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied."
+                },
+                "memo": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cleared": {
+                    "type": "string",
+                    "enum": [
+                        "cleared",
+                        "uncleared",
+                        "reconciled"
+                    ],
+                    "description": "The cleared status of the transaction"
+                },
+                "approved": {
+                    "type": "boolean",
+                    "description": "Whether or not the transaction is approved.  If not supplied, transaction will be unapproved by default."
+                },
+                "flag_color": {
+                    "type": "string",
+                    "enum": [
+                        "red",
+                        "orange",
+                        "yellow",
+                        "green",
+                        "blue",
+                        "purple",
+                        null
+                    ],
+                    "description": "The transaction flag"
+                },
+                "import_id": {
+                    "type": "string",
+                    "description": "If specified for a new transaction, the transaction will be treated as Imported and assigned this import_id.  If another transaction on the same account with this same import_id is later attempted to be created, it will be skipped to prevent duplication.  Transactions imported through File Based Import or Direct Import and not through the API, are assigned an import_id in the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'.  For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1'.  If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2'.  Using a consistent format will prevent duplicates through Direct Import and File Based Import.  If import_id is specified as null, the transaction will be treated as a user entered transaction."
+                }
+            }
+        },
+        "BulkIdWrapper": {
+            "type": "object",
+            "required": [
+                "bulk"
+            ],
+            "properties": {
+                "bulk": {
+                    "$ref": "#/definitions/BulkIds"
+                }
+            }
+        },
+        "BulkIds": {
+            "type": "object",
+            "required": [
+                "transaction_ids",
+                "duplicate_import_ids"
+            ],
+            "properties": {
+                "transaction_ids": {
+                    "type": "array",
+                    "description": "The list of Transaction IDs that were created.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "duplicate_import_ids": {
+                    "type": "array",
+                    "description": "If any Transactions were not created because they had an import_id matching a transaction already on the same account, the specified import_id(s) will be included in this list.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "BulkResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/BulkIdWrapper"
+                }
+            }
+        },
+        "BulkTransactions": {
+            "type": "object",
+            "required": [
+                "transactions"
+            ],
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SaveTransaction"
+                    }
+                }
+            }
+        },
+        "SubTransaction": {
+            "type": "object",
+            "required": [
+                "id",
+                "transaction_id",
+                "amount",
+                "memo",
+                "payee_id",
+                "category_id",
+                "transfer_account_id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "transaction_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "amount": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The subtransaction amount in milliunits format"
+                },
+                "memo": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "payee_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "category_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "transfer_account_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "If a transfer, the account_id which the subtransaction transfers to"
+                }
+            }
+        },
+        "ScheduledTransactionsResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/ScheduledTransactionsWrapper"
+                }
+            }
+        },
+        "ScheduledTransactionsWrapper": {
+            "type": "object",
+            "required": [
+                "scheduled_transactions"
+            ],
+            "properties": {
+                "scheduled_transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ScheduledTransactionDetail"
+                    }
+                }
+            }
+        },
+        "ScheduledTransactionResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/ScheduledTransactionWrapper"
+                }
+            }
+        },
+        "ScheduledTransactionWrapper": {
+            "type": "object",
+            "required": [
+                "scheduled_transaction"
+            ],
+            "properties": {
+                "scheduled_transaction": {
+                    "$ref": "#/definitions/ScheduledTransactionDetail"
+                }
+            }
+        },
+        "ScheduledTransactionSummary": {
+            "type": "object",
+            "required": [
+                "id",
+                "date_first",
+                "date_next",
+                "frequency",
+                "amount",
+                "memo",
+                "flag_color",
+                "account_id",
+                "payee_id",
+                "category_id",
+                "transfer_account_id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "date_first": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The first date for which the Scheduled Transaction was scheduled."
+                },
+                "date_next": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "The next date for which the Scheduled Transaction is scheduled."
+                },
+                "frequency": {
+                    "type": "string",
+                    "enum": [
+                        "never",
+                        "daily",
+                        "weekly",
+                        "everyOtherWeek",
+                        "twiceAMonth",
+                        "every4Weeks",
+                        "monthly",
+                        "everyOtherMonth",
+                        "every3Months",
+                        "every4Months",
+                        "twiceAYear",
+                        "yearly",
+                        "everyOtherYear"
+                    ]
+                },
+                "amount": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The scheduled transaction amount in milliunits format"
+                },
+                "memo": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "flag_color": {
+                    "type": "string",
+                    "enum": [
+                        "red",
+                        "orange",
+                        "yellow",
+                        "green",
+                        "blue",
+                        "purple",
+                        null
+                    ],
+                    "description": "The scheduled transaction flag"
+                },
+                "account_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "payee_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "category_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "transfer_account_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "If a transfer, the account_id which the scheduled transaction transfers to"
+                }
+            }
+        },
+        "ScheduledTransactionDetail": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ScheduledTransactionSummary"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "account_name",
+                        "payee_name",
+                        "category_name",
+                        "subtransactions"
+                    ],
+                    "properties": {
+                        "account_name": {
+                            "type": "string"
+                        },
+                        "payee_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "category_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "subtransactions": {
+                            "type": "array",
+                            "description": "If a split scheduled transaction, the subtransactions.",
+                            "items": {
+                                "$ref": "#/definitions/ScheduledSubTransaction"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "ScheduledSubTransaction": {
+            "type": "object",
+            "required": [
+                "id",
+                "scheduled_transaction_id",
+                "amount",
+                "memo",
+                "payee_id",
+                "category_id",
+                "transfer_account_id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "scheduled_transaction_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "amount": {
+                    "type": "number",
+                    "format": "1234000",
+                    "description": "The scheduled subtransaction amount in milliunits format"
+                },
+                "memo": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "payee_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "category_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "transfer_account_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "If a transfer, the account_id which the scheduled sub transaction transfers to"
+                }
+            }
+        },
+        "MonthSummariesResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/MonthSummariesWrapper"
+                }
+            }
+        },
+        "MonthSummariesWrapper": {
+            "type": "object",
+            "required": [
+                "months"
+            ],
+            "properties": {
+                "months": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MonthSummary"
+                    }
+                }
+            }
+        },
+        "MonthDetailResponse": {
+            "type": "object",
+            "required": [
+                "data"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/MonthDetailWrapper"
+                }
+            }
+        },
+        "MonthDetailWrapper": {
+            "type": "object",
+            "required": [
+                "month"
+            ],
+            "properties": {
+                "month": {
+                    "$ref": "#/definitions/MonthDetail"
+                }
+            }
+        },
+        "MonthSummary": {
+            "type": "object",
+            "required": [
+                "month",
+                "note",
+                "to_be_budgeted",
+                "age_of_money"
+            ],
+            "properties": {
+                "month": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "note": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "to_be_budgeted": {
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "format": "1234000",
+                    "description": "The current balance of the account in milliunits format"
+                },
+                "age_of_money": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "MonthDetail": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/MonthSummary"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "categories"
+                    ],
+                    "properties": {
+                        "categories": {
+                            "type": "array",
+                            "description": "The budget month categories",
+                            "items": {
+                                "$ref": "#/definitions/Category"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -1583,10 +1583,7 @@
                     "description": "Whether this account is closed or not"
                 },
                 "note": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "balance": {
                     "type": "number",
@@ -1724,10 +1721,7 @@
                     "type": "boolean"
                 },
                 "note": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "budgeted": {
                     "type": "number",
@@ -1807,10 +1801,7 @@
                 },
                 "transfer_account_id": {
                     "description": "If a transfer payee, the account_id to which this payee transfers to",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -1879,16 +1870,10 @@
                     "format": "uuid"
                 },
                 "latitude": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "longitude": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 }
             }
         },
@@ -1995,10 +1980,7 @@
                     "description": "The transaction amount in milliunits format"
                 },
                 "memo": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "cleared": {
                     "type": "string",
@@ -2066,16 +2048,10 @@
                             "type": "string"
                         },
                         "payee_name": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "type": "string"
                         },
                         "category_name": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "type": "string"
                         },
                         "subtransactions": {
                             "type": "array",
@@ -2120,16 +2096,10 @@
                             "type": "string"
                         },
                         "payee_name": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "type": "string"
                         },
                         "category_name": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "type": "string"
                         }
                     }
                 }
@@ -2182,10 +2152,7 @@
                     "description": "The category for the transaction.  Split and Credit Card Payment categories are not permitted and will be ignored if supplied."
                 },
                 "memo": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "cleared": {
                     "type": "string",
@@ -2304,10 +2271,7 @@
                     "description": "The subtransaction amount in milliunits format"
                 },
                 "memo": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "payee_id": {
                     "type": "string",
@@ -2425,10 +2389,7 @@
                     "description": "The scheduled transaction amount in milliunits format"
                 },
                 "memo": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "flag_color": {
                     "type": "string",
@@ -2480,16 +2441,10 @@
                             "type": "string"
                         },
                         "payee_name": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "type": "string"
                         },
                         "category_name": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "type": "string"
                         },
                         "subtransactions": {
                             "type": "array",
@@ -2528,10 +2483,7 @@
                     "description": "The scheduled subtransaction amount in milliunits format"
                 },
                 "memo": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "payee_id": {
                     "type": "string",
@@ -2609,10 +2561,7 @@
                     "format": "date"
                 },
                 "note": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "type": "string"
                 },
                 "to_be_budgeted": {
                     "type": [

--- a/swagger.json
+++ b/swagger.json
@@ -2564,18 +2564,12 @@
                     "type": "string"
                 },
                 "to_be_budgeted": {
-                    "type": [
-                        "number",
-                        "null"
-                    ],
+                    "type": "number",
                     "format": "1234000",
                     "description": "The current balance of the account in milliunits format"
                 },
                 "age_of_money": {
-                    "type": [
-                        "number",
-                        "null"
-                    ]
+                    "type": "number"
                 }
             }
         },


### PR DESCRIPTION
To generate the missing fields, I had to copy the swagger.json-file from the ynab-server and had to replace the optional types by normal ones. There won't be updates from the original API swagger.json with the local copy, but it will generate classes with every property. I'm not 100% sure what the missing optionality does, but it worked for my purposes and cannot be worse than missing fields. Feel free to merge or reject.